### PR TITLE
ci: pin golangci-lint to v2.11.2 (built with go1.26.1) for Go 1.26 co…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, develop]
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
     paths-ignore:
@@ -30,9 +30,9 @@ jobs:
           cache-dependency-path: go.sum
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: latest
+          version: v2.11.2 # built with go1.26.1, required for go 1.26+ modules
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates the continuous integration (CI) workflow configuration to align with new branch naming conventions and to use a more appropriate version of the GolangCI-Lint action. The changes ensure that CI runs on the correct branches and that linting is compatible with the project's Go version.

CI workflow updates:

* Changed the branch filter in `.github/workflows/ci.yml` so CI runs on `main` and `develop` branches instead of `main` and `dev`.

Tooling update:

* Updated the `golangci-lint-action` in `.github/workflows/ci.yml` from version 6 to version 7, and specified `v2.11.2` to ensure compatibility with Go 1.26+ modules.