### PR TITLE
fix: add await and if guard to auto-assign

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -4,18 +4,18 @@ on:
   pull_request:
     types: [opened]
 
-permissions:
-  issues: write
-  pull-requests: write
-
 jobs:
   assign:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/github-script@v7
         with:
           script: |
-            github.rest.issues.addAssignees({
+            await github.rest.issues.addAssignees({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,


### PR DESCRIPTION
This pull request updates the workflow configuration for auto-assigning pull requests. The main change is to ensure that the workflow only runs when the pull request originates from the same repository, and to move the required permissions into the specific job rather than at the workflow level.

Workflow improvements:

* Added a condition to the `assign` job so it only runs if the pull request comes from the same repository (`github.event.pull_request.head.repo.full_name == github.repository`).
* Moved the `permissions` block from the workflow level to the `assign` job, ensuring permissions are only granted when needed.

Code quality:

* Added `await` before the `github.rest.issues.addAssignees` call to properly handle the asynchronous operation.