### PR TITLE
chore: adopt testify for test assertions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-wspulse/core provides the **shared types** used across the wspulse WebSocket ecosystem: `Frame`, `Codec`, `JSONCodec`, and sentinel errors. Module path: `github.com/wspulse/core`. Package name: `wspulse`. This module has **zero external dependencies** (stdlib only).
+wspulse/core provides the **shared types** used across the wspulse WebSocket ecosystem: `Frame`, `Codec`, `JSONCodec`, and sentinel errors. Module path: `github.com/wspulse/core`. Package name: `wspulse`. This module has **zero production dependencies** (stdlib only). Test dependencies (e.g. `testify`) are permitted with justification.
 
 ## Architecture
 
@@ -69,7 +69,7 @@ All new features and design changes follow this process — do not skip steps:
 1. **Read before write** — always read the target file and relevant docs fully before editing.
 2. **Minimal changes** — one concern per edit; no drive-by refactors.
 3. **No hardcoded secrets** — all configuration via environment variables.
-4. **Zero external dependencies** — core must only depend on Go stdlib. Any change introducing an external dependency must be explicitly justified and approved.
+4. **Zero production dependencies** — core's production code must only depend on Go stdlib. Test dependencies (`_test.go` only) are permitted when justified (e.g. `testify` for assertion readability). Any change introducing a production dependency must be explicitly justified and approved.
 5. **No breaking changes without version bump** — never rename, remove, or change the signature of an exported symbol without bumping the major version. When unsure, add alongside the old symbol and deprecate.
 6. **STOP — test first, fix second** — when a bug is discovered or reported, do NOT touch production code until a failing test exists. Follow this exact sequence without skipping or reordering:
     1. Write a failing test that reproduces the bug.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ making any changes.
 ## Non-negotiable Rules
 
 1. **Read before write** — read the target file before any edit.
-2. **Zero external dependencies** — core must only depend on Go stdlib.
+2. **Zero production dependencies** — core's production code must only depend on Go stdlib. Test dependencies are permitted when justified.
 3. **No breaking changes without version bump.**
 4. **No hardcoded secrets.**
 5. **Minimal changes** — one concern per edit; no drive-by refactors.

--- a/codec_test.go
+++ b/codec_test.go
@@ -1,31 +1,27 @@
 package wspulse_test
 
 import (
-	"bytes"
 	"encoding/json"
 	"strings"
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	wspulse "github.com/wspulse/core"
 )
 
 func TestJSONCodec_FrameType_IsTextMessage(t *testing.T) {
-	if got := wspulse.JSONCodec.FrameType(); got != wspulse.TextMessage {
-		t.Errorf("FrameType: want %d (TextMessage), got %d", wspulse.TextMessage, got)
-	}
+	assert.Equal(t, wspulse.TextMessage, wspulse.JSONCodec.FrameType())
 }
 
 func TestJSONCodec_Encode_ProducesValidJSON(t *testing.T) {
 	f := wspulse.Frame{Event: "msg", Payload: []byte(`{"text":"hello"}`)}
 	data, err := wspulse.JSONCodec.Encode(f)
-	if err != nil {
-		t.Fatalf("Encode failed: %v", err)
-	}
+	require.NoError(t, err)
 	var m map[string]json.RawMessage
-	if err := json.Unmarshal(data, &m); err != nil {
-		t.Fatalf("encoded bytes are not valid JSON: %v", err)
-	}
+	require.NoError(t, json.Unmarshal(data, &m), "encoded bytes are not valid JSON")
 }
 
 func TestJSONCodec_Encode_PopulatesAllFields(t *testing.T) {
@@ -34,64 +30,45 @@ func TestJSONCodec_Encode_PopulatesAllFields(t *testing.T) {
 	var m map[string]json.RawMessage
 	_ = json.Unmarshal(data, &m)
 	assertJSONString(t, m, "event", "sys")
-	if _, ok := m["payload"]; !ok {
-		t.Error("expected 'payload' key in encoded JSON")
-	}
+	assert.Contains(t, m, "payload")
 }
 
 func TestJSONCodec_Encode_EmptyEventOmitted(t *testing.T) {
 	f := wspulse.Frame{Payload: []byte(`"data"`)}
 	data, _ := wspulse.JSONCodec.Encode(f)
-	if bytes.Contains(data, []byte(`"event"`)) {
-		t.Error("expected 'event' key to be omitted when Event is empty")
-	}
+	assert.NotContains(t, string(data), `"event"`)
 }
 
 func TestJSONCodec_Encode_PayloadIsNotBase64(t *testing.T) {
 	payload := []byte(`{"nested":{"k":"v"}}`)
 	f := wspulse.Frame{Event: "msg", Payload: payload}
 	data, _ := wspulse.JSONCodec.Encode(f)
-	if !bytes.Contains(data, []byte(`"nested"`)) {
-		t.Errorf("encoded JSON should embed payload as-is, got: %s", data)
-	}
+	assert.Contains(t, string(data), `"nested"`,
+		"encoded JSON should embed payload as-is, got: %s", data)
 }
 
 func TestJSONCodec_Decode_AllFields(t *testing.T) {
 	input := `{"event":"sys","payload":{"event":"join"}}`
 	f, err := wspulse.JSONCodec.Decode([]byte(input))
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
-	if f.Event != "sys" {
-		t.Errorf("Event: want %q, got %q", "sys", f.Event)
-	}
-	if !bytes.Contains(f.Payload, []byte(`"event"`)) {
-		t.Errorf("Payload missing 'event' key: %s", f.Payload)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "sys", f.Event)
+	assert.Contains(t, string(f.Payload), `"event"`)
 }
 
 func TestJSONCodec_Decode_MissingFieldsAreEmpty(t *testing.T) {
 	f, err := wspulse.JSONCodec.Decode([]byte(`{}`))
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
-	if f.Event != "" {
-		t.Errorf("unexpected non-empty Event: %q", f.Event)
-	}
+	require.NoError(t, err)
+	assert.Empty(t, f.Event)
 }
 
 func TestJSONCodec_Decode_InvalidJSON_ReturnsError(t *testing.T) {
 	_, err := wspulse.JSONCodec.Decode([]byte("not-json"))
-	if err == nil {
-		t.Error("expected error for invalid JSON input")
-	}
+	assert.Error(t, err)
 }
 
 func TestJSONCodec_Decode_EmptyInput_ReturnsError(t *testing.T) {
 	_, err := wspulse.JSONCodec.Decode([]byte(""))
-	if err == nil {
-		t.Error("expected error for empty input")
-	}
+	assert.Error(t, err)
 }
 
 func TestJSONCodec_Roundtrip_PreservesAllFields(t *testing.T) {
@@ -100,31 +77,19 @@ func TestJSONCodec_Roundtrip_PreservesAllFields(t *testing.T) {
 		Payload: []byte(`{"a":1,"b":true}`),
 	}
 	data, err := wspulse.JSONCodec.Encode(original)
-	if err != nil {
-		t.Fatalf("Encode failed: %v", err)
-	}
+	require.NoError(t, err)
 	decoded, err := wspulse.JSONCodec.Decode(data)
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
-	if decoded.Event != original.Event {
-		t.Errorf("Event: want %q, got %q", original.Event, decoded.Event)
-	}
-	if !bytes.Equal(decoded.Payload, original.Payload) {
-		t.Errorf("Payload: want %s, got %s", original.Payload, decoded.Payload)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, original.Event, decoded.Event)
+	assert.Equal(t, original.Payload, decoded.Payload)
 }
 
 func TestJSONCodec_Roundtrip_NilPayload(t *testing.T) {
 	original := wspulse.Frame{Event: "ping"}
 	data, _ := wspulse.JSONCodec.Encode(original)
 	decoded, err := wspulse.JSONCodec.Decode(data)
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
-	if decoded.Event != original.Event {
-		t.Errorf("Event: want %q, got %q", original.Event, decoded.Event)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, original.Event, decoded.Event)
 }
 
 // ---- Lifecycle: buffer independence -----------------------------------------
@@ -135,9 +100,7 @@ func TestJSONCodec_Decode_PayloadIsIndependentFromInput(t *testing.T) {
 	copy(original, input)
 
 	frame, err := wspulse.JSONCodec.Decode(input)
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
+	require.NoError(t, err)
 
 	// Overwrite the input buffer to simulate buffer reuse in a read loop.
 	for i := range input {
@@ -145,9 +108,8 @@ func TestJSONCodec_Decode_PayloadIsIndependentFromInput(t *testing.T) {
 	}
 
 	// The decoded Frame's Payload must remain intact.
-	if !bytes.Contains(frame.Payload, []byte(`"key"`)) {
-		t.Errorf("Payload corrupted after input buffer modification: %s", frame.Payload)
-	}
+	assert.Contains(t, string(frame.Payload), `"key"`,
+		"Payload corrupted after input buffer modification")
 }
 
 func TestJSONCodec_Encode_OutputIsIndependentFromInput(t *testing.T) {
@@ -155,9 +117,7 @@ func TestJSONCodec_Encode_OutputIsIndependentFromInput(t *testing.T) {
 	frame := wspulse.Frame{Event: "msg", Payload: payload}
 
 	data, err := wspulse.JSONCodec.Encode(frame)
-	if err != nil {
-		t.Fatalf("Encode failed: %v", err)
-	}
+	require.NoError(t, err)
 	snapshot := make([]byte, len(data))
 	copy(snapshot, data)
 
@@ -167,9 +127,7 @@ func TestJSONCodec_Encode_OutputIsIndependentFromInput(t *testing.T) {
 	}
 
 	// Encoded output must remain intact.
-	if !bytes.Equal(data, snapshot) {
-		t.Errorf("Encode output changed after input mutation: got %s", data)
-	}
+	assert.Equal(t, snapshot, data, "Encode output changed after input mutation")
 }
 
 // ---- Edge cases: Payload variants -------------------------------------------
@@ -177,60 +135,40 @@ func TestJSONCodec_Encode_OutputIsIndependentFromInput(t *testing.T) {
 func TestJSONCodec_Encode_InvalidPayload_ReturnsError(t *testing.T) {
 	frame := wspulse.Frame{Event: "msg", Payload: []byte("not valid json")}
 	_, err := wspulse.JSONCodec.Encode(frame)
-	if err == nil {
-		t.Error("expected error when Payload is not valid JSON")
-	}
+	assert.Error(t, err)
 }
 
 func TestJSONCodec_Roundtrip_NullPayload(t *testing.T) {
 	original := wspulse.Frame{Event: "msg", Payload: []byte("null")}
 	data, err := wspulse.JSONCodec.Encode(original)
-	if err != nil {
-		t.Fatalf("Encode failed: %v", err)
-	}
+	require.NoError(t, err)
 	decoded, err := wspulse.JSONCodec.Decode(data)
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
-	if string(decoded.Payload) != "null" {
-		t.Errorf("Payload: want %q, got %q", "null", string(decoded.Payload))
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "null", string(decoded.Payload))
 }
 
 func TestJSONCodec_Roundtrip_ArrayPayload(t *testing.T) {
 	original := wspulse.Frame{Event: "list", Payload: []byte(`[1,2,3]`)}
 	data, _ := wspulse.JSONCodec.Encode(original)
 	decoded, err := wspulse.JSONCodec.Decode(data)
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
-	if !bytes.Equal(decoded.Payload, original.Payload) {
-		t.Errorf("Payload: want %s, got %s", original.Payload, decoded.Payload)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, original.Payload, decoded.Payload)
 }
 
 func TestJSONCodec_Roundtrip_StringPayload(t *testing.T) {
 	original := wspulse.Frame{Event: "echo", Payload: []byte(`"hello world"`)}
 	data, _ := wspulse.JSONCodec.Encode(original)
 	decoded, err := wspulse.JSONCodec.Decode(data)
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
-	if !bytes.Equal(decoded.Payload, original.Payload) {
-		t.Errorf("Payload: want %s, got %s", original.Payload, decoded.Payload)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, original.Payload, decoded.Payload)
 }
 
 func TestJSONCodec_Roundtrip_NumericPayload(t *testing.T) {
 	original := wspulse.Frame{Event: "val", Payload: []byte(`42`)}
 	data, _ := wspulse.JSONCodec.Encode(original)
 	decoded, err := wspulse.JSONCodec.Decode(data)
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
-	if !bytes.Equal(decoded.Payload, original.Payload) {
-		t.Errorf("Payload: want %s, got %s", original.Payload, decoded.Payload)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, original.Payload, decoded.Payload)
 }
 
 func TestJSONCodec_Roundtrip_UnicodePayload(t *testing.T) {
@@ -239,16 +177,10 @@ func TestJSONCodec_Roundtrip_UnicodePayload(t *testing.T) {
 		Payload: []byte(`{"text":"你好世界 🌍"}`),
 	}
 	data, err := wspulse.JSONCodec.Encode(original)
-	if err != nil {
-		t.Fatalf("Encode failed: %v", err)
-	}
+	require.NoError(t, err)
 	decoded, err := wspulse.JSONCodec.Decode(data)
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
-	if !bytes.Equal(decoded.Payload, original.Payload) {
-		t.Errorf("Payload: want %s, got %s", original.Payload, decoded.Payload)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, original.Payload, decoded.Payload)
 }
 
 func TestJSONCodec_Roundtrip_DeeplyNestedPayload(t *testing.T) {
@@ -258,12 +190,8 @@ func TestJSONCodec_Roundtrip_DeeplyNestedPayload(t *testing.T) {
 	}
 	data, _ := wspulse.JSONCodec.Encode(original)
 	decoded, err := wspulse.JSONCodec.Decode(data)
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
-	if !bytes.Equal(decoded.Payload, original.Payload) {
-		t.Errorf("Payload: want %s, got %s", original.Payload, decoded.Payload)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, original.Payload, decoded.Payload)
 }
 
 // ---- Forward compatibility: unknown fields ----------------------------------
@@ -271,23 +199,15 @@ func TestJSONCodec_Roundtrip_DeeplyNestedPayload(t *testing.T) {
 func TestJSONCodec_Decode_ExtraFields_Ignored(t *testing.T) {
 	input := `{"event":"msg","payload":{"k":"v"},"version":2,"extra":"ignored"}`
 	frame, err := wspulse.JSONCodec.Decode([]byte(input))
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
-	if frame.Event != "msg" {
-		t.Errorf("unexpected Event: want %q, got %q", "msg", frame.Event)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "msg", frame.Event)
 }
 
 func TestJSONCodec_Decode_NullPayloadField(t *testing.T) {
 	input := `{"event":"ping","payload":null}`
 	frame, err := wspulse.JSONCodec.Decode([]byte(input))
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
-	if string(frame.Payload) != "null" {
-		t.Errorf("Payload: want %q, got %q", "null", string(frame.Payload))
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "null", string(frame.Payload))
 }
 
 // ---- Concurrency safety -----------------------------------------------------
@@ -306,18 +226,14 @@ func TestJSONCodec_ConcurrentEncodeDecode(t *testing.T) {
 				Payload: []byte(`{"data":"test"}`),
 			}
 			data, err := wspulse.JSONCodec.Encode(original)
-			if err != nil {
-				t.Errorf("Encode failed: %v", err)
+			if !assert.NoError(t, err, "Encode failed") {
 				return
 			}
 			decoded, err := wspulse.JSONCodec.Decode(data)
-			if err != nil {
-				t.Errorf("Decode failed: %v", err)
+			if !assert.NoError(t, err, "Decode failed") {
 				return
 			}
-			if decoded.Event != original.Event {
-				t.Errorf("roundtrip mismatch: got %+v", decoded)
-			}
+			assert.Equal(t, original.Event, decoded.Event, "roundtrip mismatch")
 		}()
 	}
 	waitGroup.Wait()
@@ -332,16 +248,10 @@ func TestJSONCodec_Roundtrip_LargePayload(t *testing.T) {
 	original := wspulse.Frame{Event: "bulk", Payload: payload}
 
 	data, err := wspulse.JSONCodec.Encode(original)
-	if err != nil {
-		t.Fatalf("Encode failed: %v", err)
-	}
+	require.NoError(t, err)
 	decoded, err := wspulse.JSONCodec.Decode(data)
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
-	if !bytes.Equal(decoded.Payload, original.Payload) {
-		t.Error("large payload roundtrip mismatch")
-	}
+	require.NoError(t, err)
+	assert.Equal(t, original.Payload, decoded.Payload, "large payload roundtrip mismatch")
 }
 
 // ---- Benchmarks -------------------------------------------------------------
@@ -382,16 +292,12 @@ func BenchmarkJSONCodec_Roundtrip(b *testing.B) {
 func assertJSONString(t *testing.T, m map[string]json.RawMessage, key, want string) {
 	t.Helper()
 	raw, ok := m[key]
-	if !ok {
-		t.Errorf("key %q not found in JSON", key)
+	if !assert.True(t, ok, "key %q not found in JSON", key) {
 		return
 	}
 	var got string
-	if err := json.Unmarshal(raw, &got); err != nil {
-		t.Errorf("key %q: failed to unmarshal as string: %v", key, err)
+	if !assert.NoError(t, json.Unmarshal(raw, &got), "key %q: failed to unmarshal as string", key) {
 		return
 	}
-	if got != want {
-		t.Errorf("key %q: want %q, got %q", key, want, got)
-	}
+	assert.Equal(t, want, got, "key %q", key)
 }

--- a/frame_test.go
+++ b/frame_test.go
@@ -6,28 +6,23 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	wspulse "github.com/wspulse/core"
 )
 
 func TestFrame_ZeroValue_HasEmptyFields(t *testing.T) {
 	var f wspulse.Frame
-	if f.Event != "" {
-		t.Errorf("Event: want empty, got %q", f.Event)
-	}
-	if f.Payload != nil {
-		t.Errorf("Payload: want nil, got %v", f.Payload)
-	}
+	assert.Empty(t, f.Event)
+	assert.Nil(t, f.Payload)
 }
 
 func TestFrame_FieldAssignment(t *testing.T) {
 	payload := []byte(`{"key":"val"}`)
 	f := wspulse.Frame{Event: "msg", Payload: payload}
-	if f.Event != "msg" {
-		t.Errorf("Event: want %q, got %q", "msg", f.Event)
-	}
-	if string(f.Payload) != string(payload) {
-		t.Errorf("Payload: want %s, got %s", payload, f.Payload)
-	}
+	assert.Equal(t, "msg", f.Event)
+	assert.Equal(t, payload, f.Payload)
 }
 
 func TestSentinelErrors_AreDistinct(t *testing.T) {
@@ -37,8 +32,8 @@ func TestSentinelErrors_AreDistinct(t *testing.T) {
 	}
 	for i, a := range sentinels {
 		for j, b := range sentinels {
-			if i != j && a == b {
-				t.Fatalf("errors[%d] and errors[%d] are the same: %v", i, j, a)
+			if i != j {
+				require.NotEqual(t, a, b, "errors[%d] and errors[%d] should be distinct", i, j)
 			}
 		}
 	}
@@ -53,34 +48,22 @@ func TestSentinelErrors_HaveNonEmptyMessages(t *testing.T) {
 		{"ErrSendBufferFull", wspulse.ErrSendBufferFull},
 	}
 	for _, tc := range cases {
-		if tc.err.Error() == "" {
-			t.Errorf("%s.Error() returned empty string", tc.name)
-		}
+		assert.NotEmpty(t, tc.err.Error(), "%s.Error() returned empty string", tc.name)
 	}
 }
 
 func TestMessageTypeConstants(t *testing.T) {
-	if wspulse.TextMessage != 1 {
-		t.Errorf("TextMessage: want 1, got %d", wspulse.TextMessage)
-	}
-	if wspulse.BinaryMessage != 2 {
-		t.Errorf("BinaryMessage: want 2, got %d", wspulse.BinaryMessage)
-	}
+	assert.Equal(t, 1, wspulse.TextMessage)
+	assert.Equal(t, 2, wspulse.BinaryMessage)
 }
 
 func TestWireFrame_EmptyPayload_OmittedFromJSON(t *testing.T) {
 	f := wspulse.Frame{Event: "ping"}
 	data, err := wspulse.JSONCodec.Encode(f)
-	if err != nil {
-		t.Fatalf("Encode failed: %v", err)
-	}
+	require.NoError(t, err)
 	var m map[string]json.RawMessage
-	if err := json.Unmarshal(data, &m); err != nil {
-		t.Fatalf("unmarshal failed: %v", err)
-	}
-	if _, ok := m["payload"]; ok {
-		t.Error("expected 'payload' to be absent when Payload is nil")
-	}
+	require.NoError(t, json.Unmarshal(data, &m))
+	assert.NotContains(t, m, "payload")
 }
 
 // ---- Sentinel error conventions ---------------------------------------------
@@ -94,9 +77,8 @@ func TestSentinelErrors_HaveWspulsePrefix(t *testing.T) {
 		{"ErrSendBufferFull", wspulse.ErrSendBufferFull},
 	}
 	for _, tc := range cases {
-		if !strings.HasPrefix(tc.err.Error(), "wspulse:") {
-			t.Errorf("%s.Error() = %q, want prefix %q", tc.name, tc.err.Error(), "wspulse:")
-		}
+		assert.True(t, strings.HasPrefix(tc.err.Error(), "wspulse:"),
+			"%s.Error() = %q, want prefix %q", tc.name, tc.err.Error(), "wspulse:")
 	}
 }
 
@@ -105,9 +87,7 @@ func TestSentinelErrors_SupportErrorsIs(t *testing.T) {
 		wspulse.ErrConnectionClosed,
 		errors.New("extra context"),
 	)
-	if !errors.Is(wrapped, wspulse.ErrConnectionClosed) {
-		t.Error("errors.Is should match ErrConnectionClosed in joined error")
-	}
+	assert.ErrorIs(t, wrapped, wspulse.ErrConnectionClosed)
 }
 
 // ---- Frame copy semantics (lifecycle awareness) -----------------------------
@@ -124,9 +104,8 @@ func TestFrame_PayloadSharing_AfterCopy(t *testing.T) {
 
 	// Since slices share backing arrays, the original is also affected.
 	// This test documents the expected Go behavior so users are aware.
-	if original.Payload[0] != 'X' {
-		t.Error("expected shallow copy: modifying copy's Payload should affect original")
-	}
+	assert.Equal(t, byte('X'), original.Payload[0],
+		"expected shallow copy: modifying copy's Payload should affect original")
 }
 
 func TestFrame_IndependentPayload_RequiresExplicitCopy(t *testing.T) {
@@ -143,7 +122,6 @@ func TestFrame_IndependentPayload_RequiresExplicitCopy(t *testing.T) {
 	copy(independent.Payload, original.Payload)
 
 	independent.Payload[0] = 'X'
-	if original.Payload[0] == 'X' {
-		t.Error("explicit copy should make Payload independent")
-	}
+	assert.NotEqual(t, byte('X'), original.Payload[0],
+		"explicit copy should make Payload independent")
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/wspulse/core
 
 go 1.26.0
+
+require github.com/stretchr/testify v1.11.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/router/context_test.go
+++ b/router/context_test.go
@@ -3,6 +3,9 @@ package router_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	wspulse "github.com/wspulse/core"
 	"github.com/wspulse/core/router"
 )
@@ -17,9 +20,7 @@ func TestContext_Next_ExecutesAllHandlersInOrder(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "room1"), wspulse.Frame{Event: "ping"})
 
-	if len(order) != 3 || order[0] != 1 || order[1] != 2 || order[2] != 3 {
-		t.Errorf("unexpected execution order: %v", order)
-	}
+	assert.Equal(t, []int{1, 2, 3}, order)
 }
 
 func TestContext_Abort_StopsChain(t *testing.T) {
@@ -31,9 +32,7 @@ func TestContext_Abort_StopsChain(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "room1"), wspulse.Frame{Event: "ping"})
 
-	if secondCalled {
-		t.Error("handler should not have been called after Abort")
-	}
+	assert.False(t, secondCalled, "handler should not have been called after Abort")
 }
 
 func TestContext_IsAborted_FalseBeforeAbort(t *testing.T) {
@@ -44,9 +43,7 @@ func TestContext_IsAborted_FalseBeforeAbort(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "room1"), wspulse.Frame{Event: "ping"})
 
-	if wasAborted {
-		t.Error("IsAborted should be false before Abort is called")
-	}
+	assert.False(t, wasAborted, "IsAborted should be false before Abort is called")
 }
 
 func TestContext_IsAborted_TrueAfterAbort(t *testing.T) {
@@ -61,9 +58,7 @@ func TestContext_IsAborted_TrueAfterAbort(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "room1"), wspulse.Frame{Event: "ping"})
 
-	if !abortedInMiddleware {
-		t.Error("IsAborted should be true after Abort is called")
-	}
+	assert.True(t, abortedInMiddleware, "IsAborted should be true after Abort is called")
 }
 
 func TestContext_Set_Get_RoundTrip(t *testing.T) {
@@ -76,9 +71,8 @@ func TestContext_Set_Get_RoundTrip(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "room1"), wspulse.Frame{Event: "ping"})
 
-	if !exists || got != "alice" {
-		t.Errorf("expected (alice, true), got (%v, %v)", got, exists)
-	}
+	require.True(t, exists)
+	assert.Equal(t, "alice", got)
 }
 
 func TestContext_Get_MissingKey(t *testing.T) {
@@ -89,9 +83,7 @@ func TestContext_Get_MissingKey(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "room1"), wspulse.Frame{Event: "ping"})
 
-	if exists {
-		t.Error("Get should return false for a missing key")
-	}
+	assert.False(t, exists, "Get should return false for a missing key")
 }
 
 func TestContext_MustGet_ReturnsValue(t *testing.T) {
@@ -103,9 +95,7 @@ func TestContext_MustGet_ReturnsValue(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "room1"), wspulse.Frame{Event: "ping"})
 
-	if got != "admin" {
-		t.Errorf("expected %q, got %v", "admin", got)
-	}
+	assert.Equal(t, "admin", got)
 }
 
 func TestContext_MustGet_PanicsOnMissingKey(t *testing.T) {
@@ -123,9 +113,7 @@ func TestContext_MustGet_PanicsOnMissingKey(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "room1"), wspulse.Frame{Event: "ping"})
 
-	if !panicked {
-		t.Error("MustGet should panic for a missing key")
-	}
+	assert.True(t, panicked, "MustGet should panic for a missing key")
 }
 
 func TestContext_GetString_ReturnsString(t *testing.T) {
@@ -137,9 +125,7 @@ func TestContext_GetString_ReturnsString(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "room1"), wspulse.Frame{Event: "ping"})
 
-	if got != "bob" {
-		t.Errorf("expected %q, got %q", "bob", got)
-	}
+	assert.Equal(t, "bob", got)
 }
 
 func TestContext_GetString_MissingKeyReturnsEmpty(t *testing.T) {
@@ -150,9 +136,7 @@ func TestContext_GetString_MissingKeyReturnsEmpty(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "room1"), wspulse.Frame{Event: "ping"})
 
-	if got != "" {
-		t.Errorf("expected empty string, got %q", got)
-	}
+	assert.Empty(t, got)
 }
 
 func TestContext_GetString_WrongTypeReturnsEmpty(t *testing.T) {
@@ -164,9 +148,7 @@ func TestContext_GetString_WrongTypeReturnsEmpty(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "room1"), wspulse.Frame{Event: "ping"})
 
-	if got != "" {
-		t.Errorf("expected empty string for non-string value, got %q", got)
-	}
+	assert.Empty(t, got, "expected empty string for non-string value")
 }
 
 func TestContext_Set_OverwritesExistingKey(t *testing.T) {
@@ -182,9 +164,7 @@ func TestContext_Set_OverwritesExistingKey(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "room1"), wspulse.Frame{Event: "ping"})
 
-	if got != "second" {
-		t.Errorf("expected %q, got %v", "second", got)
-	}
+	assert.Equal(t, "second", got)
 }
 
 func TestContext_ConnectionAndFrameAccessible(t *testing.T) {
@@ -202,13 +182,7 @@ func TestContext_ConnectionAndFrameAccessible(t *testing.T) {
 		wspulse.Frame{Event: "chat"},
 	)
 
-	if gotID != "conn-1" {
-		t.Errorf("expected ID %q, got %q", "conn-1", gotID)
-	}
-	if gotRoomID != "room-A" {
-		t.Errorf("expected RoomID %q, got %q", "room-A", gotRoomID)
-	}
-	if gotFrameEvent != "chat" {
-		t.Errorf("expected FrameEvent %q, got %q", "chat", gotFrameEvent)
-	}
+	assert.Equal(t, "conn-1", gotID)
+	assert.Equal(t, "room-A", gotRoomID)
+	assert.Equal(t, "chat", gotFrameEvent)
 }

--- a/router/recovery_test.go
+++ b/router/recovery_test.go
@@ -3,30 +3,22 @@ package router_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	wspulse "github.com/wspulse/core"
 	"github.com/wspulse/core/router"
 )
 
 func TestRecovery_CatchesPanicAndContinues(t *testing.T) {
-	afterRecoveryCalled := false
-
 	rtr := router.New()
 	rtr.Use(router.Recovery())
 	rtr.On("ping", func(_ *router.Context) { panic("boom") })
 
 	// Dispatch must not panic to the caller; it must be swallowed by Recovery.
-	defer func() {
-		if recover() != nil {
-			t.Error("panic escaped Recovery middleware")
-		}
-	}()
-
-	rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "ping"})
-	afterRecoveryCalled = true
-
-	if !afterRecoveryCalled {
-		t.Error("execution should continue after Dispatch when Recovery is installed")
-	}
+	require.NotPanics(t, func() {
+		rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "ping"})
+	})
 }
 
 func TestRecovery_NonPanicPathUnaffected(t *testing.T) {
@@ -38,9 +30,7 @@ func TestRecovery_NonPanicPathUnaffected(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "ping"})
 
-	if !called {
-		t.Error("handler should be called when no panic occurs")
-	}
+	assert.True(t, called, "handler should be called when no panic occurs")
 }
 
 func TestRecovery_ChainContinuesAfterRecovery(t *testing.T) {
@@ -55,21 +45,16 @@ func TestRecovery_ChainContinuesAfterRecovery(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "ping"})
 
-	if !secondCalled {
-		t.Error("subsequent middleware should be called when Recovery is installed and no panic occurs")
-	}
+	assert.True(t, secondCalled,
+		"subsequent middleware should be called when Recovery is installed and no panic occurs")
 }
 
 func TestRecovery_PanicWithNilValue(t *testing.T) {
-	defer func() {
-		if recover() != nil {
-			t.Error("nil panic should not escape Recovery middleware")
-		}
-	}()
-
 	rtr := router.New()
 	rtr.Use(router.Recovery())
 	rtr.On("ping", func(_ *router.Context) { panic(nil) }) //nolint:gocritic
 
-	rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "ping"})
+	require.NotPanics(t, func() {
+		rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "ping"})
+	})
 }

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -1,8 +1,10 @@
 package router_test
 
 import (
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	wspulse "github.com/wspulse/core"
 	"github.com/wspulse/core/router"
@@ -18,9 +20,7 @@ func TestRouter_On_DispatchRoutesToRegisteredHandler(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "ping"})
 
-	if !called {
-		t.Error("registered handler was not called")
-	}
+	assert.True(t, called, "registered handler was not called")
 }
 
 func TestRouter_On_UnmatchedFrameCallsFallback(t *testing.T) {
@@ -36,9 +36,7 @@ func TestRouter_On_UnmatchedFrameCallsFallback(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "unknown"})
 
-	if !defaultFallbackCalled {
-		t.Error("fallback was not called for unmatched frame type")
-	}
+	assert.True(t, defaultFallbackCalled, "fallback was not called for unmatched frame type")
 }
 
 func TestRouter_On_DispatchRoutesCorrectEvent(t *testing.T) {
@@ -50,9 +48,7 @@ func TestRouter_On_DispatchRoutesCorrectEvent(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "chat"})
 
-	if received != "chat" {
-		t.Errorf("expected %q, got %q", "chat", received)
-	}
+	assert.Equal(t, "chat", received)
 }
 
 // ---- middleware --------------------------------------------------------------
@@ -66,9 +62,7 @@ func TestRouter_Use_MiddlewareRunsBeforeHandler(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "ping"})
 
-	if len(order) != 2 || order[0] != "middleware" || order[1] != "handler" {
-		t.Errorf("unexpected order: %v", order)
-	}
+	assert.Equal(t, []string{"middleware", "handler"}, order)
 }
 
 func TestRouter_Use_AbortInMiddlewareBlocksHandler(t *testing.T) {
@@ -80,9 +74,7 @@ func TestRouter_Use_AbortInMiddlewareBlocksHandler(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "ping"})
 
-	if handlerCalled {
-		t.Error("handler should not be called after middleware Abort")
-	}
+	assert.False(t, handlerCalled, "handler should not be called after middleware Abort")
 }
 
 // ---- WithFallback ------------------------------------------------------------
@@ -96,9 +88,7 @@ func TestRouter_WithFallback_CalledForUnregisteredEvent(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "mystery"})
 
-	if gotEvent != "mystery" {
-		t.Errorf("expected %q, got %q", "mystery", gotEvent)
-	}
+	assert.Equal(t, "mystery", gotEvent)
 }
 
 func TestRouter_WithFallback_RegisteredEventDoesNotUseFallback(t *testing.T) {
@@ -111,18 +101,13 @@ func TestRouter_WithFallback_RegisteredEventDoesNotUseFallback(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "ping"})
 
-	if fallbackCalled {
-		t.Error("fallback should not be called for a registered event")
-	}
+	assert.False(t, fallbackCalled, "fallback should not be called for a registered event")
 }
 
 func TestRouter_WithFallback_PanicsOnNilHandler(t *testing.T) {
-	defer func() {
-		if recover() == nil {
-			t.Error("expected panic when WithFallback receives nil")
-		}
-	}()
-	router.New(router.WithFallback(nil))
+	require.Panics(t, func() {
+		router.New(router.WithFallback(nil))
+	})
 }
 
 func TestRouter_DefaultFallback_CalledForUnmatchedFrameWithNoCustomFallback(t *testing.T) {
@@ -131,82 +116,56 @@ func TestRouter_DefaultFallback_CalledForUnmatchedFrameWithNoCustomFallback(t *t
 	rtr := router.New()
 	rtr.On("ping", func(_ *router.Context) {})
 
-	defer func() {
-		if recover() != nil {
-			t.Error("defaultFallback must not panic")
-		}
-	}()
-	rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "unknown"})
+	require.NotPanics(t, func() {
+		rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "unknown"})
+	})
 }
 
 // ---- panic on misuse --------------------------------------------------------
 
 func TestRouter_On_PanicsOnEmptyEventName(t *testing.T) {
-	defer func() {
-		if recover() == nil {
-			t.Error("expected panic for empty event")
-		}
-	}()
-	rtr := router.New()
-	rtr.On("", func(_ *router.Context) {})
+	require.Panics(t, func() {
+		rtr := router.New()
+		rtr.On("", func(_ *router.Context) {})
+	})
 }
 
 func TestRouter_On_PanicsOnDuplicateRegistration(t *testing.T) {
-	defer func() {
-		if recover() == nil {
-			t.Error("expected panic for duplicate event registration")
-		}
-	}()
-	rtr := router.New()
-	rtr.On("ping", func(_ *router.Context) {})
-	rtr.On("ping", func(_ *router.Context) {})
+	require.Panics(t, func() {
+		rtr := router.New()
+		rtr.On("ping", func(_ *router.Context) {})
+		rtr.On("ping", func(_ *router.Context) {})
+	})
 }
 
 func TestRouter_On_PanicsOnNoHandlers(t *testing.T) {
-	defer func() {
-		if recover() == nil {
-			t.Error("expected panic when On called with no handlers")
-		}
-	}()
-	rtr := router.New()
-	rtr.On("ping")
+	require.Panics(t, func() {
+		rtr := router.New()
+		rtr.On("ping")
+	})
 }
 
 func TestRouter_On_PanicsOnNilHandler(t *testing.T) {
-	defer func() {
-		if recover() == nil {
-			t.Error("expected panic when On called with nil handler")
-		}
-	}()
-	rtr := router.New()
-	rtr.On("ping", nil)
+	require.Panics(t, func() {
+		rtr := router.New()
+		rtr.On("ping", nil)
+	})
 }
 
 func TestRouter_Use_PanicsOnNilHandler(t *testing.T) {
-	defer func() {
-		if recover() == nil {
-			t.Error("expected panic when Use called with nil handler")
-		}
-	}()
-	rtr := router.New()
-	rtr.Use(nil)
+	require.Panics(t, func() {
+		rtr := router.New()
+		rtr.Use(nil)
+	})
 }
 
 func TestRouter_CombineHandlers_PanicsWhenChainTooLong(t *testing.T) {
 	defer func() {
-		err := recover()
-		if err == nil {
-			t.Error("expected panic for oversized handler chain")
-			return
-		}
-		msg, ok := err.(string)
-		if !ok {
-			t.Errorf("expected string panic, got %T: %v", err, err)
-			return
-		}
-		if !strings.Contains(msg, "exceeds maximum") {
-			t.Errorf("panic message %q does not mention exceeds maximum", msg)
-		}
+		r := recover()
+		require.NotNil(t, r, "expected panic for oversized handler chain")
+		msg, ok := r.(string)
+		require.True(t, ok, "expected string panic, got %T: %v", r, r)
+		assert.Contains(t, msg, "exceeds maximum")
 	}()
 
 	rtr := router.New()


### PR DESCRIPTION
## Summary

Adopt `github.com/stretchr/testify` (`assert` / `require`) across all test files to improve assertion readability and error messages. Pure assertion migration, no behaviour changes.

Ref: wspulse/.github#19

## Changes

- Added `github.com/stretchr/testify` as a test dependency
- Migrated `frame_test.go`: raw `if/t.Errorf` checks to `assert.Equal`, `assert.Empty`, `assert.Nil`, `assert.ErrorIs`, `require.NoError`, `require.NotEqual`
- Migrated `codec_test.go`: same patterns plus `assert.Contains`/`assert.NotContains` for byte content checks, removed `bytes` import. Migrated `assertJSONString` helper to use `assert` internally
- Migrated `router/router_test.go`: `defer/recover` panic tests to `require.Panics`/`require.NotPanics`, boolean checks to `assert.True`/`assert.False`
- Migrated `router/context_test.go`: multi-condition checks to `assert.Equal` with slice literals, `require.True` for preconditions
- Migrated `router/recovery_test.go`: `defer/recover` not-panic assertions to `require.NotPanics`

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR