### PR TITLE
feat: add Transport interface for WebSocket abstraction

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,6 +8,7 @@ wspulse/core provides the **shared types** used across the wspulse WebSocket eco
 
 - **`frame.go`** — `Frame` struct (the minimal transport unit), WebSocket message type constants (`TextMessage`, `BinaryMessage`), and shared sentinel errors (`ErrConnectionClosed`, `ErrSendBufferFull`).
 - **`codec.go`** — `Codec` interface (`Encode`, `Decode`, `FrameType`), default `JSONCodec` implementation, and the unexported `wireFrame`/`jsonCodec` types.
+- **`transport.go`** — `Transport` interface abstracting WebSocket connections for testability. `*gorilla/websocket.Conn` satisfies it via duck typing.
 - **`router/`** — Gin-style event router (`Router`, `Context`, `Connection`, `HandlerFunc`, `Recovery`). Dispatches inbound `Frame` values by `Frame.Event` through a global middleware + per-event handler chain. Lazy chain building, `sync.Pool`-backed `Context` recycling, atomic fast path for steady-state dispatches.
 
 ## Development Workflow

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-wspulse/core provides the **shared types** used across the wspulse WebSocket ecosystem: `Frame`, `Codec`, `JSONCodec`, and sentinel errors. Module path: `github.com/wspulse/core`. Package name: `wspulse`. This module has **zero production dependencies** (stdlib only). Test dependencies (e.g. `testify`) are permitted with justification.
+wspulse/core provides the **shared types** used across the wspulse WebSocket ecosystem: `Frame`, `Codec`, `JSONCodec`, `Transport`, and sentinel errors. Module path: `github.com/wspulse/core`. Package name: `wspulse`. This module has **zero production dependencies** (stdlib only). Test dependencies (e.g. `testify`) are permitted with justification.
 
 ## Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ making any changes.
 
 - `frame.go` — `Frame` struct, message type constants, sentinel errors
 - `codec.go` — `Codec` interface, `JSONCodec` implementation
+- `transport.go` — `Transport` interface (WebSocket connection abstraction)
 - `router/router.go` — `Router`, `Use`, `On`, `Dispatch`
 - `router/context.go` — `Context`, `HandlerFunc`, `HandlersChain`, `abortIndex`
 - `router/conn.go` — `Connection` interface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `Transport` interface — abstracts WebSocket connection for testability. `*gorilla/websocket.Conn` satisfies it via duck typing.
+
 ### Removed
 
 - **BREAKING**: `Frame.ID` field removed — transport layer does not use it. Applications needing message IDs should use Payload.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Shared types for the [wspulse](https://github.com/wspulse) WebSocket ecosystem.
 
-This module provides `Frame`, `Codec`, `JSONCodec`, and sentinel errors used by both [wspulse/server](https://github.com/wspulse/server) and [wspulse/client-go](https://github.com/wspulse/client-go). It has **zero external dependencies** (Go stdlib only).
+This module provides `Frame`, `Codec`, `JSONCodec`, `Transport`, and sentinel errors used by both [wspulse/server](https://github.com/wspulse/server) and [wspulse/client-go](https://github.com/wspulse/client-go). It has **zero production dependencies** (Go stdlib only).
 
 **Status:** v0 — API is being stabilized. Module path: `github.com/wspulse/core`.
 
@@ -28,8 +28,7 @@ import wspulse "github.com/wspulse/core"
 
 // Create a frame
 frame := wspulse.Frame{
-    ID:      "msg-001",
-    Event:    "msg",
+    Event:   "msg",
     Payload: []byte(`{"text":"hello"}`),
 }
 
@@ -61,20 +60,6 @@ if errors.Is(err, wspulse.ErrSendBufferFull) {
     // outbound buffer full, frame was dropped
 }
 ```
-
----
-
-## Public API
-
-| Symbol                | Description                                                     |
-| --------------------- | --------------------------------------------------------------- |
-| `Frame`               | Transport unit: `ID`, `Event`, `Payload []byte`                 |
-| `Codec`               | Interface: `Encode(Frame)`, `Decode([]byte)`, `FrameType() int` |
-| `JSONCodec`           | Default codec — JSON text frames                                |
-| `TextMessage`         | WebSocket text frame type constant (`1`)                        |
-| `BinaryMessage`       | WebSocket binary frame type constant (`2`)                      |
-| `ErrConnectionClosed` | Sentinel: connection is closed                                  |
-| `ErrSendBufferFull`   | Sentinel: send buffer full, frame dropped                       |
 
 ---
 

--- a/transport.go
+++ b/transport.go
@@ -3,7 +3,7 @@ package wspulse
 import "time"
 
 // Transport abstracts the WebSocket connection for testability.
-// *gorilla/websocket.Conn satisfies this interface via duck typing —
+// gorilla/websocket.Conn satisfies this interface via duck typing —
 // no wrapper or adapter is needed in production code.
 type Transport interface {
 	// ReadMessage reads a complete message from the connection.

--- a/transport.go
+++ b/transport.go
@@ -1,0 +1,33 @@
+package wspulse
+
+import "time"
+
+// Transport abstracts the WebSocket connection for testability.
+// *gorilla/websocket.Conn satisfies this interface via duck typing —
+// no wrapper or adapter is needed in production code.
+type Transport interface {
+	// ReadMessage reads a complete message from the connection.
+	ReadMessage() (messageType int, p []byte, err error)
+
+	// WriteMessage writes a complete message to the connection.
+	WriteMessage(messageType int, data []byte) error
+
+	// SetReadLimit sets the maximum size in bytes for a message read
+	// from the connection.
+	SetReadLimit(limit int64)
+
+	// SetReadDeadline sets the read deadline on the underlying
+	// network connection.
+	SetReadDeadline(t time.Time) error
+
+	// SetWriteDeadline sets the write deadline on the underlying
+	// network connection.
+	SetWriteDeadline(t time.Time) error
+
+	// SetPongHandler sets the handler for pong messages received
+	// from the peer.
+	SetPongHandler(h func(appData string) error)
+
+	// Close closes the underlying network connection.
+	Close() error
+}

--- a/transport.go
+++ b/transport.go
@@ -7,9 +7,12 @@ import "time"
 // no wrapper or adapter is needed in production code.
 type Transport interface {
 	// ReadMessage reads a complete message from the connection.
+	// The returned messageType is TextMessage (1) or BinaryMessage (2).
 	ReadMessage() (messageType int, p []byte, err error)
 
 	// WriteMessage writes a complete message to the connection.
+	// messageType should be TextMessage (1) or BinaryMessage (2),
+	// consistent with Codec.FrameType.
 	WriteMessage(messageType int, data []byte) error
 
 	// SetReadLimit sets the maximum size in bytes for a message read


### PR DESCRIPTION
## Summary

Add a shared `Transport` interface that abstracts the WebSocket connection (`*gorilla/websocket.Conn`) for testability. This enables component tests with mock transport — eliminating flaky integration tests caused by real TCP I/O under race detector.

Ref: wspulse/.github#20

## Changes

- Added `transport.go` with `Transport` interface (7 methods: `ReadMessage`, `WriteMessage`, `SetReadLimit`, `SetReadDeadline`, `SetWriteDeadline`, `SetPongHandler`, `Close`)
- `*gorilla/websocket.Conn` satisfies this interface via duck typing — zero production behavior change
- Updated CHANGELOG `[Unreleased]`

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] New public API: includes GoDoc comments