### PR TITLE
release: merge develop to main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,10 +8,17 @@
 
 ## Checklist
 
+### Required
+
 - [ ] `make check` passes (`fmt` → `lint` → `test`)
 - [ ] Each commit represents exactly one logical change
 - [ ] Commit messages follow the format in `commit-message-instructions.md`
 - [ ] No unrelated code reformatting in this PR
+
+### Conditional (list only those that apply)
+
+<!-- Remove items that do not apply to this PR. All remaining items must be checked before merge. -->
+
 - [ ] Bug fix: includes a test that fails before the fix and passes after
 - [ ] New public API: includes GoDoc comments
 - [ ] Breaking change: major version bump discussed in linked issue

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -80,10 +80,9 @@ All new features and design changes follow this process — do not skip steps:
     6. If you are about to edit production code and no failing test exists yet — stop and go back to step 1.
 7. **STOP — before every commit, verify this checklist:**
     1. Run `make check` (fmt → lint → test) and confirm it passes. Skip if the commit contains only non-code changes (e.g. documentation, comments, Markdown).
-    2. Run GitHub Copilot code review (`github.copilot.chat.review.changes`) on the working-tree diff and resolve every comment before proceeding.
-    3. Commit message follows [commit-message-instructions.md](instructions/commit-message-instructions.md): correct type, subject ≤ 50 chars, numbered body items stating reason → change.
-    4. This commit contains exactly one logical change — no unrelated modifications.
-    5. If any item fails — fix it before committing.
+    2. Commit message follows [commit-message-instructions.md](instructions/commit-message-instructions.md): correct type, subject ≤ 50 chars, numbered body items stating reason → change.
+    3. This commit contains exactly one logical change — no unrelated modifications.
+    4. If any item fails — fix it before committing.
 8. **Accuracy** — if you have questions or need clarification, ask the user. Do not make assumptions without confirming.
 9. **Language consistency** — when the user writes in Traditional Chinese, respond in Traditional Chinese; otherwise respond in English.
 10. **Panic policy — fail early, never at steady-state runtime** — Enforce errors at the earliest possible phase:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -41,6 +41,7 @@ make tidy       # tidy module dependencies
     - `fix/<name>` — quick fix (e.g. config, docs, CI)
     - `chore/<name>` — maintenance, CI/CD, dependencies, docs
     - CI triggers on all branch prefixes above and on PRs targeting `main`/`develop`. Tags do **not** trigger CI (the tag is created after CI already passed). Open a PR into `develop`; `develop` requires status checks to pass.
+  - **Pull request description**: must follow the repo's `.github/PULL_REQUEST_TEMPLATE.md`. Fill in every section (Summary, Changes, Checklist). Do not invent custom formats.
 - **Tests**: co-located with source (`_test.go`). Cover happy path and at least one error path. Required for new public functions.
   - **Test-first for bug fixes**: **mandatory** — see Critical Rule 6 for the required step-by-step procedure. Do not touch production code without a prior failing test.
   - **Benchmarks**: changes to encoding or frame allocation must include a benchmark. Verify with `make bench`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-wspulse/core provides the **shared types** used across the wspulse WebSocket ecosystem: `Frame`, `Codec`, `JSONCodec`, and sentinel errors. Module path: `github.com/wspulse/core`. Package name: `wspulse`. This module has **zero external dependencies** (stdlib only).
+wspulse/core provides the **shared types** used across the wspulse WebSocket ecosystem: `Frame`, `Codec`, `JSONCodec`, and sentinel errors. Module path: `github.com/wspulse/core`. Package name: `wspulse`. This module has **zero production dependencies** (stdlib only). Test dependencies (e.g. `testify`) are permitted with justification.
 
 ## Architecture
 
@@ -69,7 +69,7 @@ All new features and design changes follow this process — do not skip steps:
 1. **Read before write** — always read the target file and relevant docs fully before editing.
 2. **Minimal changes** — one concern per edit; no drive-by refactors.
 3. **No hardcoded secrets** — all configuration via environment variables.
-4. **Zero external dependencies** — core must only depend on Go stdlib. Any change introducing an external dependency must be explicitly justified and approved.
+4. **Zero production dependencies** — core's production code must only depend on Go stdlib. Test dependencies (`_test.go` only) are permitted when justified (e.g. `testify` for assertion readability). Any change introducing a production dependency must be explicitly justified and approved.
 5. **No breaking changes without version bump** — never rename, remove, or change the signature of an exported symbol without bumping the major version. When unsure, add alongside the old symbol and deprecate.
 6. **STOP — test first, fix second** — when a bug is discovered or reported, do NOT touch production code until a failing test exists. Follow this exact sequence without skipping or reordering:
     1. Write a failing test that reproduces the bug.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,6 +8,7 @@ wspulse/core provides the **shared types** used across the wspulse WebSocket eco
 
 - **`frame.go`** — `Frame` struct (the minimal transport unit), WebSocket message type constants (`TextMessage`, `BinaryMessage`), and shared sentinel errors (`ErrConnectionClosed`, `ErrSendBufferFull`).
 - **`codec.go`** — `Codec` interface (`Encode`, `Decode`, `FrameType`), default `JSONCodec` implementation, and the unexported `wireFrame`/`jsonCodec` types.
+- **`transport.go`** — `Transport` interface abstracting WebSocket connections for testability. `*gorilla/websocket.Conn` satisfies it via duck typing.
 - **`router/`** — Gin-style event router (`Router`, `Context`, `Connection`, `HandlerFunc`, `Recovery`). Dispatches inbound `Frame` values by `Frame.Event` through a global middleware + per-event handler chain. Lazy chain building, `sync.Pool`-backed `Context` recycling, atomic fast path for steady-state dispatches.
 
 ## Development Workflow

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-wspulse/core provides the **shared types** used across the wspulse WebSocket ecosystem: `Frame`, `Codec`, `JSONCodec`, and sentinel errors. Module path: `github.com/wspulse/core`. Package name: `wspulse`. This module has **zero production dependencies** (stdlib only). Test dependencies (e.g. `testify`) are permitted with justification.
+wspulse/core provides the **shared types** used across the wspulse WebSocket ecosystem: `Frame`, `Codec`, `JSONCodec`, `Transport`, and sentinel errors. Module path: `github.com/wspulse/core`. Package name: `wspulse`. This module has **zero production dependencies** (stdlib only). Test dependencies (e.g. `testify`) are permitted with justification.
 
 ## Architecture
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,6 +52,18 @@ make tidy       # tidy module dependencies
 - **Error format**: wrap errors as `fmt.Errorf("wspulse: <context>: %w", err)`; define sentinel errors as `errors.New("wspulse: <description>")`.
 - **File encoding**: all files must be UTF-8 without BOM. Do not use any other encoding.
 
+## Feature Workflow
+
+All new features and design changes follow this process — do not skip steps:
+
+1. **Plan** — write idea to `doc/local/plan/<name>.md` (local only, git-ignored)
+2. **Quick discussion** — feasibility + value check
+3. **Go / No-go** — kill or proceed
+4. **Layer check** — transport layer (wspulse implements) or application layer (write docs recipe instead)
+5. **Issue RFC** — open GitHub issue on `wspulse/.github` with summary, scope, impact assessment, priority label + milestone
+6. **Design discussion** — API surface, cross-SDK parity, contract/protocol updates, edge cases
+7. **Task** — feature branch from `develop`, implement with tests, CHANGELOG entry, PR following template
+
 ## Critical Rules
 
 1. **Read before write** — always read the target file and relevant docs fully before editing.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -60,9 +60,9 @@ All new features and design changes follow this process — do not skip steps:
 2. **Quick discussion** — feasibility + value check
 3. **Go / No-go** — kill or proceed
 4. **Layer check** — transport layer (wspulse implements) or application layer (write docs recipe instead)
-5. **Issue RFC** — open GitHub issue on `wspulse/.github` with summary, scope, impact assessment, priority label + milestone
+5. **Issue** — repo-scoped work: open issue on this repo. Cross-repo/global work: open issue on [`wspulse/.github`](https://github.com/wspulse/.github). Include summary, scope, impact assessment, priority label + milestone
 6. **Design discussion** — API surface, cross-SDK parity, contract/protocol updates, edge cases
-7. **Task** — feature branch from `develop`, implement with tests, CHANGELOG entry, PR following template
+7. **Task** — feature branch from `develop`, implement with tests, CHANGELOG entry, PR following template. **Repo-scoped**: link PR to the issue. **Global**: each PR mentions the global issue (e.g., `wspulse/.github#N`); after opening a PR, comment on the global issue with the PR link
 
 ## Critical Rules
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,12 +6,8 @@ on:
       - 'v*.*.*'
 
 jobs:
-  check:
-    uses: wspulse/.github/.github/workflows/go-check.yml@main
-
   release:
     runs-on: ubuntu-latest
-    needs: [check]
     permissions:
       contents: write
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ making any changes.
 ## Non-negotiable Rules
 
 1. **Read before write** — read the target file before any edit.
-2. **Zero external dependencies** — core must only depend on Go stdlib.
+2. **Zero production dependencies** — core's production code must only depend on Go stdlib. Test dependencies are permitted when justified.
 3. **No breaking changes without version bump.**
 4. **No hardcoded secrets.**
 5. **Minimal changes** — one concern per edit; no drive-by refactors.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ making any changes.
 
 - `frame.go` — `Frame` struct, message type constants, sentinel errors
 - `codec.go` — `Codec` interface, `JSONCodec` implementation
+- `transport.go` — `Transport` interface (WebSocket connection abstraction)
 - `router/router.go` — `Router`, `Use`, `On`, `Dispatch`
 - `router/context.go` — `Context`, `HandlerFunc`, `HandlersChain`, `abortIndex`
 - `router/conn.go` — `Connection` interface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: `Frame.ID` field removed — transport layer does not use it. Applications needing message IDs should use Payload.
+
 ---
 
 ## [0.2.0] - 2026-03-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-### Changed
+### Removed
 
 - **BREAKING**: `Frame.ID` field removed — transport layer does not use it. Applications needing message IDs should use Payload.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `Transport` interface — abstracts WebSocket connection for testability. `*gorilla/websocket.Conn` satisfies it via duck typing.
+
 ### Removed
 
 - **BREAKING**: `Frame.ID` field removed — transport layer does not use it. Applications needing message IDs should use Payload.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,9 +56,9 @@ wspulse/core follows semantic versioning. Any change that removes, renames, or a
 - Adding a method to an exported interface is also a breaking change.
 - When in doubt, add a new symbol alongside the old one.
 
-## Zero Dependencies
+## Dependencies
 
-core must have **zero external dependencies**. It may only use the Go standard library. Any PR that introduces an external dependency will be rejected.
+core must have **zero production dependencies** — production code may only use the Go standard library. Test dependencies (`_test.go` only) are permitted when justified (e.g. `testify` for assertion readability). Any PR that introduces a production dependency will be rejected.
 
 ## Pull Request Guidelines
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Shared types for the [wspulse](https://github.com/wspulse) WebSocket ecosystem.
 
-This module provides `Frame`, `Codec`, `JSONCodec`, and sentinel errors used by both [wspulse/server](https://github.com/wspulse/server) and [wspulse/client-go](https://github.com/wspulse/client-go). It has **zero external dependencies** (Go stdlib only).
+This module provides `Frame`, `Codec`, `JSONCodec`, `Transport`, and sentinel errors used by both [wspulse/server](https://github.com/wspulse/server) and [wspulse/client-go](https://github.com/wspulse/client-go). It has **zero production dependencies** (Go stdlib only).
 
 **Status:** v0 — API is being stabilized. Module path: `github.com/wspulse/core`.
 
@@ -28,8 +28,7 @@ import wspulse "github.com/wspulse/core"
 
 // Create a frame
 frame := wspulse.Frame{
-    ID:      "msg-001",
-    Event:    "msg",
+    Event:   "msg",
     Payload: []byte(`{"text":"hello"}`),
 }
 
@@ -61,20 +60,6 @@ if errors.Is(err, wspulse.ErrSendBufferFull) {
     // outbound buffer full, frame was dropped
 }
 ```
-
----
-
-## Public API
-
-| Symbol                | Description                                                     |
-| --------------------- | --------------------------------------------------------------- |
-| `Frame`               | Transport unit: `ID`, `Event`, `Payload []byte`                 |
-| `Codec`               | Interface: `Encode(Frame)`, `Decode([]byte)`, `FrameType() int` |
-| `JSONCodec`           | Default codec — JSON text frames                                |
-| `TextMessage`         | WebSocket text frame type constant (`1`)                        |
-| `BinaryMessage`       | WebSocket binary frame type constant (`2`)                      |
-| `ErrConnectionClosed` | Sentinel: connection is closed                                  |
-| `ErrSendBufferFull`   | Sentinel: send buffer full, frame dropped                       |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ Every frame is encoded on the wire as a JSON object. The `"event"` field is what
 
 ```json
 {
-  "id": "msg-001",
   "event": "chat.message",
   "payload": { "text": "hello" }
 }

--- a/codec.go
+++ b/codec.go
@@ -18,7 +18,6 @@ type Codec interface {
 // wireFrame is the JSON on-the-wire representation of a Frame.
 // Payload is treated as json.RawMessage to avoid base64 encoding.
 type wireFrame struct {
-	ID      string          `json:"id,omitempty"`
 	Event   string          `json:"event,omitempty"`
 	Payload json.RawMessage `json:"payload,omitempty"`
 }
@@ -35,7 +34,6 @@ func (jsonCodec) FrameType() int { return TextMessage }
 
 func (jsonCodec) Encode(f Frame) ([]byte, error) {
 	return json.Marshal(wireFrame{
-		ID:      f.ID,
 		Event:   f.Event,
 		Payload: json.RawMessage(f.Payload),
 	})
@@ -47,7 +45,6 @@ func (jsonCodec) Decode(data []byte) (Frame, error) {
 		return Frame{}, err
 	}
 	return Frame{
-		ID:      wf.ID,
 		Event:   wf.Event,
 		Payload: []byte(wf.Payload),
 	}, nil

--- a/codec_test.go
+++ b/codec_test.go
@@ -17,7 +17,7 @@ func TestJSONCodec_FrameType_IsTextMessage(t *testing.T) {
 }
 
 func TestJSONCodec_Encode_ProducesValidJSON(t *testing.T) {
-	f := wspulse.Frame{ID: "1", Event: "msg", Payload: []byte(`{"text":"hello"}`)}
+	f := wspulse.Frame{Event: "msg", Payload: []byte(`{"text":"hello"}`)}
 	data, err := wspulse.JSONCodec.Encode(f)
 	if err != nil {
 		t.Fatalf("Encode failed: %v", err)
@@ -29,27 +29,18 @@ func TestJSONCodec_Encode_ProducesValidJSON(t *testing.T) {
 }
 
 func TestJSONCodec_Encode_PopulatesAllFields(t *testing.T) {
-	f := wspulse.Frame{ID: "abc", Event: "sys", Payload: []byte(`{"x":1}`)}
+	f := wspulse.Frame{Event: "sys", Payload: []byte(`{"x":1}`)}
 	data, _ := wspulse.JSONCodec.Encode(f)
 	var m map[string]json.RawMessage
 	_ = json.Unmarshal(data, &m)
-	assertJSONString(t, m, "id", "abc")
 	assertJSONString(t, m, "event", "sys")
 	if _, ok := m["payload"]; !ok {
 		t.Error("expected 'payload' key in encoded JSON")
 	}
 }
 
-func TestJSONCodec_Encode_EmptyIDOmitted(t *testing.T) {
-	f := wspulse.Frame{Event: "msg", Payload: []byte(`"data"`)}
-	data, _ := wspulse.JSONCodec.Encode(f)
-	if bytes.Contains(data, []byte(`"id"`)) {
-		t.Error("expected 'id' key to be omitted when ID is empty")
-	}
-}
-
 func TestJSONCodec_Encode_EmptyEventOmitted(t *testing.T) {
-	f := wspulse.Frame{ID: "1", Payload: []byte(`"data"`)}
+	f := wspulse.Frame{Payload: []byte(`"data"`)}
 	data, _ := wspulse.JSONCodec.Encode(f)
 	if bytes.Contains(data, []byte(`"event"`)) {
 		t.Error("expected 'event' key to be omitted when Event is empty")
@@ -66,13 +57,10 @@ func TestJSONCodec_Encode_PayloadIsNotBase64(t *testing.T) {
 }
 
 func TestJSONCodec_Decode_AllFields(t *testing.T) {
-	input := `{"id":"x","event":"sys","payload":{"event":"join"}}`
+	input := `{"event":"sys","payload":{"event":"join"}}`
 	f, err := wspulse.JSONCodec.Decode([]byte(input))
 	if err != nil {
 		t.Fatalf("Decode failed: %v", err)
-	}
-	if f.ID != "x" {
-		t.Errorf("ID: want %q, got %q", "x", f.ID)
 	}
 	if f.Event != "sys" {
 		t.Errorf("Event: want %q, got %q", "sys", f.Event)
@@ -87,8 +75,8 @@ func TestJSONCodec_Decode_MissingFieldsAreEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Decode failed: %v", err)
 	}
-	if f.ID != "" || f.Event != "" {
-		t.Errorf("unexpected non-empty fields: ID=%q Event=%q", f.ID, f.Event)
+	if f.Event != "" {
+		t.Errorf("unexpected non-empty Event: %q", f.Event)
 	}
 }
 
@@ -108,7 +96,6 @@ func TestJSONCodec_Decode_EmptyInput_ReturnsError(t *testing.T) {
 
 func TestJSONCodec_Roundtrip_PreservesAllFields(t *testing.T) {
 	original := wspulse.Frame{
-		ID:      "round-1",
 		Event:   "msg",
 		Payload: []byte(`{"a":1,"b":true}`),
 	}
@@ -120,9 +107,6 @@ func TestJSONCodec_Roundtrip_PreservesAllFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Decode failed: %v", err)
 	}
-	if decoded.ID != original.ID {
-		t.Errorf("ID: want %q, got %q", original.ID, decoded.ID)
-	}
 	if decoded.Event != original.Event {
 		t.Errorf("Event: want %q, got %q", original.Event, decoded.Event)
 	}
@@ -132,14 +116,14 @@ func TestJSONCodec_Roundtrip_PreservesAllFields(t *testing.T) {
 }
 
 func TestJSONCodec_Roundtrip_NilPayload(t *testing.T) {
-	original := wspulse.Frame{ID: "no-payload", Event: "ping"}
+	original := wspulse.Frame{Event: "ping"}
 	data, _ := wspulse.JSONCodec.Encode(original)
 	decoded, err := wspulse.JSONCodec.Decode(data)
 	if err != nil {
 		t.Fatalf("Decode failed: %v", err)
 	}
-	if decoded.ID != original.ID || decoded.Event != original.Event {
-		t.Errorf("fields changed: got %+v", decoded)
+	if decoded.Event != original.Event {
+		t.Errorf("Event: want %q, got %q", original.Event, decoded.Event)
 	}
 }
 
@@ -285,13 +269,13 @@ func TestJSONCodec_Roundtrip_DeeplyNestedPayload(t *testing.T) {
 // ---- Forward compatibility: unknown fields ----------------------------------
 
 func TestJSONCodec_Decode_ExtraFields_Ignored(t *testing.T) {
-	input := `{"id":"1","event":"msg","payload":{"k":"v"},"version":2,"extra":"ignored"}`
+	input := `{"event":"msg","payload":{"k":"v"},"version":2,"extra":"ignored"}`
 	frame, err := wspulse.JSONCodec.Decode([]byte(input))
 	if err != nil {
 		t.Fatalf("Decode failed: %v", err)
 	}
-	if frame.ID != "1" || frame.Event != "msg" {
-		t.Errorf("unexpected field values: %+v", frame)
+	if frame.Event != "msg" {
+		t.Errorf("unexpected Event: want %q, got %q", "msg", frame.Event)
 	}
 }
 
@@ -318,7 +302,6 @@ func TestJSONCodec_ConcurrentEncodeDecode(t *testing.T) {
 			defer waitGroup.Done()
 
 			original := wspulse.Frame{
-				ID:      "concurrent",
 				Event:   "msg",
 				Payload: []byte(`{"data":"test"}`),
 			}
@@ -332,7 +315,7 @@ func TestJSONCodec_ConcurrentEncodeDecode(t *testing.T) {
 				t.Errorf("Decode failed: %v", err)
 				return
 			}
-			if decoded.ID != original.ID || decoded.Event != original.Event {
+			if decoded.Event != original.Event {
 				t.Errorf("roundtrip mismatch: got %+v", decoded)
 			}
 		}()
@@ -365,7 +348,6 @@ func TestJSONCodec_Roundtrip_LargePayload(t *testing.T) {
 
 func BenchmarkJSONCodec_Encode(b *testing.B) {
 	frame := wspulse.Frame{
-		ID:      "bench-1",
 		Event:   "msg",
 		Payload: []byte(`{"user":"alice","text":"hello"}`),
 	}
@@ -376,7 +358,7 @@ func BenchmarkJSONCodec_Encode(b *testing.B) {
 }
 
 func BenchmarkJSONCodec_Decode(b *testing.B) {
-	data := []byte(`{"id":"bench-1","event":"msg","payload":{"user":"alice","text":"hello"}}`)
+	data := []byte(`{"event":"msg","payload":{"user":"alice","text":"hello"}}`)
 	b.ReportAllocs()
 	for b.Loop() {
 		_, _ = wspulse.JSONCodec.Decode(data)
@@ -385,7 +367,6 @@ func BenchmarkJSONCodec_Decode(b *testing.B) {
 
 func BenchmarkJSONCodec_Roundtrip(b *testing.B) {
 	frame := wspulse.Frame{
-		ID:      "bench-rt",
 		Event:   "msg",
 		Payload: []byte(`{"user":"alice","text":"hello"}`),
 	}

--- a/codec_test.go
+++ b/codec_test.go
@@ -1,31 +1,27 @@
 package wspulse_test
 
 import (
-	"bytes"
 	"encoding/json"
 	"strings"
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	wspulse "github.com/wspulse/core"
 )
 
 func TestJSONCodec_FrameType_IsTextMessage(t *testing.T) {
-	if got := wspulse.JSONCodec.FrameType(); got != wspulse.TextMessage {
-		t.Errorf("FrameType: want %d (TextMessage), got %d", wspulse.TextMessage, got)
-	}
+	assert.Equal(t, wspulse.TextMessage, wspulse.JSONCodec.FrameType())
 }
 
 func TestJSONCodec_Encode_ProducesValidJSON(t *testing.T) {
 	f := wspulse.Frame{Event: "msg", Payload: []byte(`{"text":"hello"}`)}
 	data, err := wspulse.JSONCodec.Encode(f)
-	if err != nil {
-		t.Fatalf("Encode failed: %v", err)
-	}
+	require.NoError(t, err)
 	var m map[string]json.RawMessage
-	if err := json.Unmarshal(data, &m); err != nil {
-		t.Fatalf("encoded bytes are not valid JSON: %v", err)
-	}
+	require.NoError(t, json.Unmarshal(data, &m), "encoded bytes are not valid JSON")
 }
 
 func TestJSONCodec_Encode_PopulatesAllFields(t *testing.T) {
@@ -34,64 +30,45 @@ func TestJSONCodec_Encode_PopulatesAllFields(t *testing.T) {
 	var m map[string]json.RawMessage
 	_ = json.Unmarshal(data, &m)
 	assertJSONString(t, m, "event", "sys")
-	if _, ok := m["payload"]; !ok {
-		t.Error("expected 'payload' key in encoded JSON")
-	}
+	assert.Contains(t, m, "payload")
 }
 
 func TestJSONCodec_Encode_EmptyEventOmitted(t *testing.T) {
 	f := wspulse.Frame{Payload: []byte(`"data"`)}
 	data, _ := wspulse.JSONCodec.Encode(f)
-	if bytes.Contains(data, []byte(`"event"`)) {
-		t.Error("expected 'event' key to be omitted when Event is empty")
-	}
+	assert.NotContains(t, string(data), `"event"`)
 }
 
 func TestJSONCodec_Encode_PayloadIsNotBase64(t *testing.T) {
 	payload := []byte(`{"nested":{"k":"v"}}`)
 	f := wspulse.Frame{Event: "msg", Payload: payload}
 	data, _ := wspulse.JSONCodec.Encode(f)
-	if !bytes.Contains(data, []byte(`"nested"`)) {
-		t.Errorf("encoded JSON should embed payload as-is, got: %s", data)
-	}
+	assert.Contains(t, string(data), `"nested"`,
+		"encoded JSON should embed payload as-is, got: %s", data)
 }
 
 func TestJSONCodec_Decode_AllFields(t *testing.T) {
 	input := `{"event":"sys","payload":{"event":"join"}}`
 	f, err := wspulse.JSONCodec.Decode([]byte(input))
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
-	if f.Event != "sys" {
-		t.Errorf("Event: want %q, got %q", "sys", f.Event)
-	}
-	if !bytes.Contains(f.Payload, []byte(`"event"`)) {
-		t.Errorf("Payload missing 'event' key: %s", f.Payload)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "sys", f.Event)
+	assert.Contains(t, string(f.Payload), `"event"`)
 }
 
 func TestJSONCodec_Decode_MissingFieldsAreEmpty(t *testing.T) {
 	f, err := wspulse.JSONCodec.Decode([]byte(`{}`))
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
-	if f.Event != "" {
-		t.Errorf("unexpected non-empty Event: %q", f.Event)
-	}
+	require.NoError(t, err)
+	assert.Empty(t, f.Event)
 }
 
 func TestJSONCodec_Decode_InvalidJSON_ReturnsError(t *testing.T) {
 	_, err := wspulse.JSONCodec.Decode([]byte("not-json"))
-	if err == nil {
-		t.Error("expected error for invalid JSON input")
-	}
+	assert.Error(t, err)
 }
 
 func TestJSONCodec_Decode_EmptyInput_ReturnsError(t *testing.T) {
 	_, err := wspulse.JSONCodec.Decode([]byte(""))
-	if err == nil {
-		t.Error("expected error for empty input")
-	}
+	assert.Error(t, err)
 }
 
 func TestJSONCodec_Roundtrip_PreservesAllFields(t *testing.T) {
@@ -100,31 +77,19 @@ func TestJSONCodec_Roundtrip_PreservesAllFields(t *testing.T) {
 		Payload: []byte(`{"a":1,"b":true}`),
 	}
 	data, err := wspulse.JSONCodec.Encode(original)
-	if err != nil {
-		t.Fatalf("Encode failed: %v", err)
-	}
+	require.NoError(t, err)
 	decoded, err := wspulse.JSONCodec.Decode(data)
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
-	if decoded.Event != original.Event {
-		t.Errorf("Event: want %q, got %q", original.Event, decoded.Event)
-	}
-	if !bytes.Equal(decoded.Payload, original.Payload) {
-		t.Errorf("Payload: want %s, got %s", original.Payload, decoded.Payload)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, original.Event, decoded.Event)
+	assert.Equal(t, original.Payload, decoded.Payload)
 }
 
 func TestJSONCodec_Roundtrip_NilPayload(t *testing.T) {
 	original := wspulse.Frame{Event: "ping"}
 	data, _ := wspulse.JSONCodec.Encode(original)
 	decoded, err := wspulse.JSONCodec.Decode(data)
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
-	if decoded.Event != original.Event {
-		t.Errorf("Event: want %q, got %q", original.Event, decoded.Event)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, original.Event, decoded.Event)
 }
 
 // ---- Lifecycle: buffer independence -----------------------------------------
@@ -135,9 +100,7 @@ func TestJSONCodec_Decode_PayloadIsIndependentFromInput(t *testing.T) {
 	copy(original, input)
 
 	frame, err := wspulse.JSONCodec.Decode(input)
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
+	require.NoError(t, err)
 
 	// Overwrite the input buffer to simulate buffer reuse in a read loop.
 	for i := range input {
@@ -145,9 +108,8 @@ func TestJSONCodec_Decode_PayloadIsIndependentFromInput(t *testing.T) {
 	}
 
 	// The decoded Frame's Payload must remain intact.
-	if !bytes.Contains(frame.Payload, []byte(`"key"`)) {
-		t.Errorf("Payload corrupted after input buffer modification: %s", frame.Payload)
-	}
+	assert.Contains(t, string(frame.Payload), `"key"`,
+		"Payload corrupted after input buffer modification")
 }
 
 func TestJSONCodec_Encode_OutputIsIndependentFromInput(t *testing.T) {
@@ -155,9 +117,7 @@ func TestJSONCodec_Encode_OutputIsIndependentFromInput(t *testing.T) {
 	frame := wspulse.Frame{Event: "msg", Payload: payload}
 
 	data, err := wspulse.JSONCodec.Encode(frame)
-	if err != nil {
-		t.Fatalf("Encode failed: %v", err)
-	}
+	require.NoError(t, err)
 	snapshot := make([]byte, len(data))
 	copy(snapshot, data)
 
@@ -167,9 +127,7 @@ func TestJSONCodec_Encode_OutputIsIndependentFromInput(t *testing.T) {
 	}
 
 	// Encoded output must remain intact.
-	if !bytes.Equal(data, snapshot) {
-		t.Errorf("Encode output changed after input mutation: got %s", data)
-	}
+	assert.Equal(t, snapshot, data, "Encode output changed after input mutation")
 }
 
 // ---- Edge cases: Payload variants -------------------------------------------
@@ -177,60 +135,40 @@ func TestJSONCodec_Encode_OutputIsIndependentFromInput(t *testing.T) {
 func TestJSONCodec_Encode_InvalidPayload_ReturnsError(t *testing.T) {
 	frame := wspulse.Frame{Event: "msg", Payload: []byte("not valid json")}
 	_, err := wspulse.JSONCodec.Encode(frame)
-	if err == nil {
-		t.Error("expected error when Payload is not valid JSON")
-	}
+	assert.Error(t, err)
 }
 
 func TestJSONCodec_Roundtrip_NullPayload(t *testing.T) {
 	original := wspulse.Frame{Event: "msg", Payload: []byte("null")}
 	data, err := wspulse.JSONCodec.Encode(original)
-	if err != nil {
-		t.Fatalf("Encode failed: %v", err)
-	}
+	require.NoError(t, err)
 	decoded, err := wspulse.JSONCodec.Decode(data)
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
-	if string(decoded.Payload) != "null" {
-		t.Errorf("Payload: want %q, got %q", "null", string(decoded.Payload))
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "null", string(decoded.Payload))
 }
 
 func TestJSONCodec_Roundtrip_ArrayPayload(t *testing.T) {
 	original := wspulse.Frame{Event: "list", Payload: []byte(`[1,2,3]`)}
 	data, _ := wspulse.JSONCodec.Encode(original)
 	decoded, err := wspulse.JSONCodec.Decode(data)
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
-	if !bytes.Equal(decoded.Payload, original.Payload) {
-		t.Errorf("Payload: want %s, got %s", original.Payload, decoded.Payload)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, original.Payload, decoded.Payload)
 }
 
 func TestJSONCodec_Roundtrip_StringPayload(t *testing.T) {
 	original := wspulse.Frame{Event: "echo", Payload: []byte(`"hello world"`)}
 	data, _ := wspulse.JSONCodec.Encode(original)
 	decoded, err := wspulse.JSONCodec.Decode(data)
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
-	if !bytes.Equal(decoded.Payload, original.Payload) {
-		t.Errorf("Payload: want %s, got %s", original.Payload, decoded.Payload)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, original.Payload, decoded.Payload)
 }
 
 func TestJSONCodec_Roundtrip_NumericPayload(t *testing.T) {
 	original := wspulse.Frame{Event: "val", Payload: []byte(`42`)}
 	data, _ := wspulse.JSONCodec.Encode(original)
 	decoded, err := wspulse.JSONCodec.Decode(data)
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
-	if !bytes.Equal(decoded.Payload, original.Payload) {
-		t.Errorf("Payload: want %s, got %s", original.Payload, decoded.Payload)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, original.Payload, decoded.Payload)
 }
 
 func TestJSONCodec_Roundtrip_UnicodePayload(t *testing.T) {
@@ -239,16 +177,10 @@ func TestJSONCodec_Roundtrip_UnicodePayload(t *testing.T) {
 		Payload: []byte(`{"text":"你好世界 🌍"}`),
 	}
 	data, err := wspulse.JSONCodec.Encode(original)
-	if err != nil {
-		t.Fatalf("Encode failed: %v", err)
-	}
+	require.NoError(t, err)
 	decoded, err := wspulse.JSONCodec.Decode(data)
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
-	if !bytes.Equal(decoded.Payload, original.Payload) {
-		t.Errorf("Payload: want %s, got %s", original.Payload, decoded.Payload)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, original.Payload, decoded.Payload)
 }
 
 func TestJSONCodec_Roundtrip_DeeplyNestedPayload(t *testing.T) {
@@ -258,12 +190,8 @@ func TestJSONCodec_Roundtrip_DeeplyNestedPayload(t *testing.T) {
 	}
 	data, _ := wspulse.JSONCodec.Encode(original)
 	decoded, err := wspulse.JSONCodec.Decode(data)
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
-	if !bytes.Equal(decoded.Payload, original.Payload) {
-		t.Errorf("Payload: want %s, got %s", original.Payload, decoded.Payload)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, original.Payload, decoded.Payload)
 }
 
 // ---- Forward compatibility: unknown fields ----------------------------------
@@ -271,23 +199,15 @@ func TestJSONCodec_Roundtrip_DeeplyNestedPayload(t *testing.T) {
 func TestJSONCodec_Decode_ExtraFields_Ignored(t *testing.T) {
 	input := `{"event":"msg","payload":{"k":"v"},"version":2,"extra":"ignored"}`
 	frame, err := wspulse.JSONCodec.Decode([]byte(input))
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
-	if frame.Event != "msg" {
-		t.Errorf("unexpected Event: want %q, got %q", "msg", frame.Event)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "msg", frame.Event)
 }
 
 func TestJSONCodec_Decode_NullPayloadField(t *testing.T) {
 	input := `{"event":"ping","payload":null}`
 	frame, err := wspulse.JSONCodec.Decode([]byte(input))
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
-	if string(frame.Payload) != "null" {
-		t.Errorf("Payload: want %q, got %q", "null", string(frame.Payload))
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "null", string(frame.Payload))
 }
 
 // ---- Concurrency safety -----------------------------------------------------
@@ -306,18 +226,14 @@ func TestJSONCodec_ConcurrentEncodeDecode(t *testing.T) {
 				Payload: []byte(`{"data":"test"}`),
 			}
 			data, err := wspulse.JSONCodec.Encode(original)
-			if err != nil {
-				t.Errorf("Encode failed: %v", err)
+			if !assert.NoError(t, err, "Encode failed") {
 				return
 			}
 			decoded, err := wspulse.JSONCodec.Decode(data)
-			if err != nil {
-				t.Errorf("Decode failed: %v", err)
+			if !assert.NoError(t, err, "Decode failed") {
 				return
 			}
-			if decoded.Event != original.Event {
-				t.Errorf("roundtrip mismatch: got %+v", decoded)
-			}
+			assert.Equal(t, original.Event, decoded.Event, "roundtrip mismatch")
 		}()
 	}
 	waitGroup.Wait()
@@ -332,16 +248,10 @@ func TestJSONCodec_Roundtrip_LargePayload(t *testing.T) {
 	original := wspulse.Frame{Event: "bulk", Payload: payload}
 
 	data, err := wspulse.JSONCodec.Encode(original)
-	if err != nil {
-		t.Fatalf("Encode failed: %v", err)
-	}
+	require.NoError(t, err)
 	decoded, err := wspulse.JSONCodec.Decode(data)
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
-	if !bytes.Equal(decoded.Payload, original.Payload) {
-		t.Error("large payload roundtrip mismatch")
-	}
+	require.NoError(t, err)
+	assert.Equal(t, original.Payload, decoded.Payload, "large payload roundtrip mismatch")
 }
 
 // ---- Benchmarks -------------------------------------------------------------
@@ -382,16 +292,12 @@ func BenchmarkJSONCodec_Roundtrip(b *testing.B) {
 func assertJSONString(t *testing.T, m map[string]json.RawMessage, key, want string) {
 	t.Helper()
 	raw, ok := m[key]
-	if !ok {
-		t.Errorf("key %q not found in JSON", key)
+	if !assert.True(t, ok, "key %q not found in JSON", key) {
 		return
 	}
 	var got string
-	if err := json.Unmarshal(raw, &got); err != nil {
-		t.Errorf("key %q: failed to unmarshal as string: %v", key, err)
+	if !assert.NoError(t, json.Unmarshal(raw, &got), "key %q: failed to unmarshal as string", key) {
 		return
 	}
-	if got != want {
-		t.Errorf("key %q: want %q, got %q", key, want, got)
-	}
+	assert.Equal(t, want, got, "key %q", key)
 }

--- a/frame.go
+++ b/frame.go
@@ -18,10 +18,6 @@ const (
 // When using JSONCodec (the default), Payload must be valid JSON bytes (e.g. output of
 // json.Marshal). When using a binary codec, Payload is the codec-encoded bytes.
 type Frame struct {
-	// ID uniquely identifies this frame. Used for ACK correlation.
-	// If empty on Send, no ID is set on the wire.
-	ID string
-
 	// Event identifies the frame purpose. wspulse does not interpret this value.
 	// Conventional values: "msg" (user data), "sys" (system event), "ack" (acknowledgement).
 	Event string

--- a/frame_test.go
+++ b/frame_test.go
@@ -11,9 +11,6 @@ import (
 
 func TestFrame_ZeroValue_HasEmptyFields(t *testing.T) {
 	var f wspulse.Frame
-	if f.ID != "" {
-		t.Errorf("ID: want empty, got %q", f.ID)
-	}
 	if f.Event != "" {
 		t.Errorf("Event: want empty, got %q", f.Event)
 	}
@@ -24,10 +21,7 @@ func TestFrame_ZeroValue_HasEmptyFields(t *testing.T) {
 
 func TestFrame_FieldAssignment(t *testing.T) {
 	payload := []byte(`{"key":"val"}`)
-	f := wspulse.Frame{ID: "abc", Event: "msg", Payload: payload}
-	if f.ID != "abc" {
-		t.Errorf("ID: want %q, got %q", "abc", f.ID)
-	}
+	f := wspulse.Frame{Event: "msg", Payload: payload}
 	if f.Event != "msg" {
 		t.Errorf("Event: want %q, got %q", "msg", f.Event)
 	}
@@ -120,7 +114,6 @@ func TestSentinelErrors_SupportErrorsIs(t *testing.T) {
 
 func TestFrame_PayloadSharing_AfterCopy(t *testing.T) {
 	original := wspulse.Frame{
-		ID:      "orig",
 		Event:   "msg",
 		Payload: []byte(`{"data":"original"}`),
 	}
@@ -138,14 +131,12 @@ func TestFrame_PayloadSharing_AfterCopy(t *testing.T) {
 
 func TestFrame_IndependentPayload_RequiresExplicitCopy(t *testing.T) {
 	original := wspulse.Frame{
-		ID:      "orig",
 		Event:   "msg",
 		Payload: []byte(`{"data":"safe"}`),
 	}
 
 	// Proper deep copy pattern for Frame.
 	independent := wspulse.Frame{
-		ID:    original.ID,
 		Event: original.Event,
 	}
 	independent.Payload = make([]byte, len(original.Payload))

--- a/frame_test.go
+++ b/frame_test.go
@@ -6,28 +6,23 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	wspulse "github.com/wspulse/core"
 )
 
 func TestFrame_ZeroValue_HasEmptyFields(t *testing.T) {
 	var f wspulse.Frame
-	if f.Event != "" {
-		t.Errorf("Event: want empty, got %q", f.Event)
-	}
-	if f.Payload != nil {
-		t.Errorf("Payload: want nil, got %v", f.Payload)
-	}
+	assert.Empty(t, f.Event)
+	assert.Nil(t, f.Payload)
 }
 
 func TestFrame_FieldAssignment(t *testing.T) {
 	payload := []byte(`{"key":"val"}`)
 	f := wspulse.Frame{Event: "msg", Payload: payload}
-	if f.Event != "msg" {
-		t.Errorf("Event: want %q, got %q", "msg", f.Event)
-	}
-	if string(f.Payload) != string(payload) {
-		t.Errorf("Payload: want %s, got %s", payload, f.Payload)
-	}
+	assert.Equal(t, "msg", f.Event)
+	assert.Equal(t, payload, f.Payload)
 }
 
 func TestSentinelErrors_AreDistinct(t *testing.T) {
@@ -37,8 +32,8 @@ func TestSentinelErrors_AreDistinct(t *testing.T) {
 	}
 	for i, a := range sentinels {
 		for j, b := range sentinels {
-			if i != j && a == b {
-				t.Fatalf("errors[%d] and errors[%d] are the same: %v", i, j, a)
+			if i != j {
+				require.NotEqual(t, a, b, "errors[%d] and errors[%d] should be distinct", i, j)
 			}
 		}
 	}
@@ -53,34 +48,22 @@ func TestSentinelErrors_HaveNonEmptyMessages(t *testing.T) {
 		{"ErrSendBufferFull", wspulse.ErrSendBufferFull},
 	}
 	for _, tc := range cases {
-		if tc.err.Error() == "" {
-			t.Errorf("%s.Error() returned empty string", tc.name)
-		}
+		assert.NotEmpty(t, tc.err.Error(), "%s.Error() returned empty string", tc.name)
 	}
 }
 
 func TestMessageTypeConstants(t *testing.T) {
-	if wspulse.TextMessage != 1 {
-		t.Errorf("TextMessage: want 1, got %d", wspulse.TextMessage)
-	}
-	if wspulse.BinaryMessage != 2 {
-		t.Errorf("BinaryMessage: want 2, got %d", wspulse.BinaryMessage)
-	}
+	assert.Equal(t, 1, wspulse.TextMessage)
+	assert.Equal(t, 2, wspulse.BinaryMessage)
 }
 
 func TestWireFrame_EmptyPayload_OmittedFromJSON(t *testing.T) {
 	f := wspulse.Frame{Event: "ping"}
 	data, err := wspulse.JSONCodec.Encode(f)
-	if err != nil {
-		t.Fatalf("Encode failed: %v", err)
-	}
+	require.NoError(t, err)
 	var m map[string]json.RawMessage
-	if err := json.Unmarshal(data, &m); err != nil {
-		t.Fatalf("unmarshal failed: %v", err)
-	}
-	if _, ok := m["payload"]; ok {
-		t.Error("expected 'payload' to be absent when Payload is nil")
-	}
+	require.NoError(t, json.Unmarshal(data, &m))
+	assert.NotContains(t, m, "payload")
 }
 
 // ---- Sentinel error conventions ---------------------------------------------
@@ -94,9 +77,8 @@ func TestSentinelErrors_HaveWspulsePrefix(t *testing.T) {
 		{"ErrSendBufferFull", wspulse.ErrSendBufferFull},
 	}
 	for _, tc := range cases {
-		if !strings.HasPrefix(tc.err.Error(), "wspulse:") {
-			t.Errorf("%s.Error() = %q, want prefix %q", tc.name, tc.err.Error(), "wspulse:")
-		}
+		assert.True(t, strings.HasPrefix(tc.err.Error(), "wspulse:"),
+			"%s.Error() = %q, want prefix %q", tc.name, tc.err.Error(), "wspulse:")
 	}
 }
 
@@ -105,9 +87,7 @@ func TestSentinelErrors_SupportErrorsIs(t *testing.T) {
 		wspulse.ErrConnectionClosed,
 		errors.New("extra context"),
 	)
-	if !errors.Is(wrapped, wspulse.ErrConnectionClosed) {
-		t.Error("errors.Is should match ErrConnectionClosed in joined error")
-	}
+	assert.ErrorIs(t, wrapped, wspulse.ErrConnectionClosed)
 }
 
 // ---- Frame copy semantics (lifecycle awareness) -----------------------------
@@ -124,9 +104,8 @@ func TestFrame_PayloadSharing_AfterCopy(t *testing.T) {
 
 	// Since slices share backing arrays, the original is also affected.
 	// This test documents the expected Go behavior so users are aware.
-	if original.Payload[0] != 'X' {
-		t.Error("expected shallow copy: modifying copy's Payload should affect original")
-	}
+	assert.Equal(t, byte('X'), original.Payload[0],
+		"expected shallow copy: modifying copy's Payload should affect original")
 }
 
 func TestFrame_IndependentPayload_RequiresExplicitCopy(t *testing.T) {
@@ -143,7 +122,6 @@ func TestFrame_IndependentPayload_RequiresExplicitCopy(t *testing.T) {
 	copy(independent.Payload, original.Payload)
 
 	independent.Payload[0] = 'X'
-	if original.Payload[0] == 'X' {
-		t.Error("explicit copy should make Payload independent")
-	}
+	assert.NotEqual(t, byte('X'), original.Payload[0],
+		"explicit copy should make Payload independent")
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/wspulse/core
 
 go 1.26.0
+
+require github.com/stretchr/testify v1.11.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/router/context_test.go
+++ b/router/context_test.go
@@ -3,6 +3,9 @@ package router_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	wspulse "github.com/wspulse/core"
 	"github.com/wspulse/core/router"
 )
@@ -17,9 +20,7 @@ func TestContext_Next_ExecutesAllHandlersInOrder(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "room1"), wspulse.Frame{Event: "ping"})
 
-	if len(order) != 3 || order[0] != 1 || order[1] != 2 || order[2] != 3 {
-		t.Errorf("unexpected execution order: %v", order)
-	}
+	assert.Equal(t, []int{1, 2, 3}, order)
 }
 
 func TestContext_Abort_StopsChain(t *testing.T) {
@@ -31,9 +32,7 @@ func TestContext_Abort_StopsChain(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "room1"), wspulse.Frame{Event: "ping"})
 
-	if secondCalled {
-		t.Error("handler should not have been called after Abort")
-	}
+	assert.False(t, secondCalled, "handler should not have been called after Abort")
 }
 
 func TestContext_IsAborted_FalseBeforeAbort(t *testing.T) {
@@ -44,9 +43,7 @@ func TestContext_IsAborted_FalseBeforeAbort(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "room1"), wspulse.Frame{Event: "ping"})
 
-	if wasAborted {
-		t.Error("IsAborted should be false before Abort is called")
-	}
+	assert.False(t, wasAborted, "IsAborted should be false before Abort is called")
 }
 
 func TestContext_IsAborted_TrueAfterAbort(t *testing.T) {
@@ -61,9 +58,7 @@ func TestContext_IsAborted_TrueAfterAbort(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "room1"), wspulse.Frame{Event: "ping"})
 
-	if !abortedInMiddleware {
-		t.Error("IsAborted should be true after Abort is called")
-	}
+	assert.True(t, abortedInMiddleware, "IsAborted should be true after Abort is called")
 }
 
 func TestContext_Set_Get_RoundTrip(t *testing.T) {
@@ -76,9 +71,8 @@ func TestContext_Set_Get_RoundTrip(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "room1"), wspulse.Frame{Event: "ping"})
 
-	if !exists || got != "alice" {
-		t.Errorf("expected (alice, true), got (%v, %v)", got, exists)
-	}
+	require.True(t, exists)
+	assert.Equal(t, "alice", got)
 }
 
 func TestContext_Get_MissingKey(t *testing.T) {
@@ -89,9 +83,7 @@ func TestContext_Get_MissingKey(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "room1"), wspulse.Frame{Event: "ping"})
 
-	if exists {
-		t.Error("Get should return false for a missing key")
-	}
+	assert.False(t, exists, "Get should return false for a missing key")
 }
 
 func TestContext_MustGet_ReturnsValue(t *testing.T) {
@@ -103,9 +95,7 @@ func TestContext_MustGet_ReturnsValue(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "room1"), wspulse.Frame{Event: "ping"})
 
-	if got != "admin" {
-		t.Errorf("expected %q, got %v", "admin", got)
-	}
+	assert.Equal(t, "admin", got)
 }
 
 func TestContext_MustGet_PanicsOnMissingKey(t *testing.T) {
@@ -123,9 +113,7 @@ func TestContext_MustGet_PanicsOnMissingKey(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "room1"), wspulse.Frame{Event: "ping"})
 
-	if !panicked {
-		t.Error("MustGet should panic for a missing key")
-	}
+	assert.True(t, panicked, "MustGet should panic for a missing key")
 }
 
 func TestContext_GetString_ReturnsString(t *testing.T) {
@@ -137,9 +125,7 @@ func TestContext_GetString_ReturnsString(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "room1"), wspulse.Frame{Event: "ping"})
 
-	if got != "bob" {
-		t.Errorf("expected %q, got %q", "bob", got)
-	}
+	assert.Equal(t, "bob", got)
 }
 
 func TestContext_GetString_MissingKeyReturnsEmpty(t *testing.T) {
@@ -150,9 +136,7 @@ func TestContext_GetString_MissingKeyReturnsEmpty(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "room1"), wspulse.Frame{Event: "ping"})
 
-	if got != "" {
-		t.Errorf("expected empty string, got %q", got)
-	}
+	assert.Empty(t, got)
 }
 
 func TestContext_GetString_WrongTypeReturnsEmpty(t *testing.T) {
@@ -164,9 +148,7 @@ func TestContext_GetString_WrongTypeReturnsEmpty(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "room1"), wspulse.Frame{Event: "ping"})
 
-	if got != "" {
-		t.Errorf("expected empty string for non-string value, got %q", got)
-	}
+	assert.Empty(t, got, "expected empty string for non-string value")
 }
 
 func TestContext_Set_OverwritesExistingKey(t *testing.T) {
@@ -182,9 +164,7 @@ func TestContext_Set_OverwritesExistingKey(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "room1"), wspulse.Frame{Event: "ping"})
 
-	if got != "second" {
-		t.Errorf("expected %q, got %v", "second", got)
-	}
+	assert.Equal(t, "second", got)
 }
 
 func TestContext_ConnectionAndFrameAccessible(t *testing.T) {
@@ -202,13 +182,7 @@ func TestContext_ConnectionAndFrameAccessible(t *testing.T) {
 		wspulse.Frame{Event: "chat"},
 	)
 
-	if gotID != "conn-1" {
-		t.Errorf("expected ID %q, got %q", "conn-1", gotID)
-	}
-	if gotRoomID != "room-A" {
-		t.Errorf("expected RoomID %q, got %q", "room-A", gotRoomID)
-	}
-	if gotFrameEvent != "chat" {
-		t.Errorf("expected FrameEvent %q, got %q", "chat", gotFrameEvent)
-	}
+	assert.Equal(t, "conn-1", gotID)
+	assert.Equal(t, "room-A", gotRoomID)
+	assert.Equal(t, "chat", gotFrameEvent)
 }

--- a/router/recovery_test.go
+++ b/router/recovery_test.go
@@ -3,30 +3,22 @@ package router_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	wspulse "github.com/wspulse/core"
 	"github.com/wspulse/core/router"
 )
 
 func TestRecovery_CatchesPanicAndContinues(t *testing.T) {
-	afterRecoveryCalled := false
-
 	rtr := router.New()
 	rtr.Use(router.Recovery())
 	rtr.On("ping", func(_ *router.Context) { panic("boom") })
 
 	// Dispatch must not panic to the caller; it must be swallowed by Recovery.
-	defer func() {
-		if recover() != nil {
-			t.Error("panic escaped Recovery middleware")
-		}
-	}()
-
-	rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "ping"})
-	afterRecoveryCalled = true
-
-	if !afterRecoveryCalled {
-		t.Error("execution should continue after Dispatch when Recovery is installed")
-	}
+	require.NotPanics(t, func() {
+		rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "ping"})
+	})
 }
 
 func TestRecovery_NonPanicPathUnaffected(t *testing.T) {
@@ -38,9 +30,7 @@ func TestRecovery_NonPanicPathUnaffected(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "ping"})
 
-	if !called {
-		t.Error("handler should be called when no panic occurs")
-	}
+	assert.True(t, called, "handler should be called when no panic occurs")
 }
 
 func TestRecovery_ChainContinuesAfterRecovery(t *testing.T) {
@@ -55,21 +45,16 @@ func TestRecovery_ChainContinuesAfterRecovery(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "ping"})
 
-	if !secondCalled {
-		t.Error("subsequent middleware should be called when Recovery is installed and no panic occurs")
-	}
+	assert.True(t, secondCalled,
+		"subsequent middleware should be called when Recovery is installed and no panic occurs")
 }
 
 func TestRecovery_PanicWithNilValue(t *testing.T) {
-	defer func() {
-		if recover() != nil {
-			t.Error("nil panic should not escape Recovery middleware")
-		}
-	}()
-
 	rtr := router.New()
 	rtr.Use(router.Recovery())
 	rtr.On("ping", func(_ *router.Context) { panic(nil) }) //nolint:gocritic
 
-	rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "ping"})
+	require.NotPanics(t, func() {
+		rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "ping"})
+	})
 }

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -1,8 +1,10 @@
 package router_test
 
 import (
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	wspulse "github.com/wspulse/core"
 	"github.com/wspulse/core/router"
@@ -18,9 +20,7 @@ func TestRouter_On_DispatchRoutesToRegisteredHandler(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "ping"})
 
-	if !called {
-		t.Error("registered handler was not called")
-	}
+	assert.True(t, called, "registered handler was not called")
 }
 
 func TestRouter_On_UnmatchedFrameCallsFallback(t *testing.T) {
@@ -36,9 +36,7 @@ func TestRouter_On_UnmatchedFrameCallsFallback(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "unknown"})
 
-	if !defaultFallbackCalled {
-		t.Error("fallback was not called for unmatched frame type")
-	}
+	assert.True(t, defaultFallbackCalled, "fallback was not called for unmatched frame type")
 }
 
 func TestRouter_On_DispatchRoutesCorrectEvent(t *testing.T) {
@@ -50,9 +48,7 @@ func TestRouter_On_DispatchRoutesCorrectEvent(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "chat"})
 
-	if received != "chat" {
-		t.Errorf("expected %q, got %q", "chat", received)
-	}
+	assert.Equal(t, "chat", received)
 }
 
 // ---- middleware --------------------------------------------------------------
@@ -66,9 +62,7 @@ func TestRouter_Use_MiddlewareRunsBeforeHandler(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "ping"})
 
-	if len(order) != 2 || order[0] != "middleware" || order[1] != "handler" {
-		t.Errorf("unexpected order: %v", order)
-	}
+	assert.Equal(t, []string{"middleware", "handler"}, order)
 }
 
 func TestRouter_Use_AbortInMiddlewareBlocksHandler(t *testing.T) {
@@ -80,9 +74,7 @@ func TestRouter_Use_AbortInMiddlewareBlocksHandler(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "ping"})
 
-	if handlerCalled {
-		t.Error("handler should not be called after middleware Abort")
-	}
+	assert.False(t, handlerCalled, "handler should not be called after middleware Abort")
 }
 
 // ---- WithFallback ------------------------------------------------------------
@@ -96,9 +88,7 @@ func TestRouter_WithFallback_CalledForUnregisteredEvent(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "mystery"})
 
-	if gotEvent != "mystery" {
-		t.Errorf("expected %q, got %q", "mystery", gotEvent)
-	}
+	assert.Equal(t, "mystery", gotEvent)
 }
 
 func TestRouter_WithFallback_RegisteredEventDoesNotUseFallback(t *testing.T) {
@@ -111,18 +101,13 @@ func TestRouter_WithFallback_RegisteredEventDoesNotUseFallback(t *testing.T) {
 
 	rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "ping"})
 
-	if fallbackCalled {
-		t.Error("fallback should not be called for a registered event")
-	}
+	assert.False(t, fallbackCalled, "fallback should not be called for a registered event")
 }
 
 func TestRouter_WithFallback_PanicsOnNilHandler(t *testing.T) {
-	defer func() {
-		if recover() == nil {
-			t.Error("expected panic when WithFallback receives nil")
-		}
-	}()
-	router.New(router.WithFallback(nil))
+	require.Panics(t, func() {
+		router.New(router.WithFallback(nil))
+	})
 }
 
 func TestRouter_DefaultFallback_CalledForUnmatchedFrameWithNoCustomFallback(t *testing.T) {
@@ -131,82 +116,56 @@ func TestRouter_DefaultFallback_CalledForUnmatchedFrameWithNoCustomFallback(t *t
 	rtr := router.New()
 	rtr.On("ping", func(_ *router.Context) {})
 
-	defer func() {
-		if recover() != nil {
-			t.Error("defaultFallback must not panic")
-		}
-	}()
-	rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "unknown"})
+	require.NotPanics(t, func() {
+		rtr.Dispatch(newMockConnection("c1", "r1"), wspulse.Frame{Event: "unknown"})
+	})
 }
 
 // ---- panic on misuse --------------------------------------------------------
 
 func TestRouter_On_PanicsOnEmptyEventName(t *testing.T) {
-	defer func() {
-		if recover() == nil {
-			t.Error("expected panic for empty event")
-		}
-	}()
-	rtr := router.New()
-	rtr.On("", func(_ *router.Context) {})
+	require.Panics(t, func() {
+		rtr := router.New()
+		rtr.On("", func(_ *router.Context) {})
+	})
 }
 
 func TestRouter_On_PanicsOnDuplicateRegistration(t *testing.T) {
-	defer func() {
-		if recover() == nil {
-			t.Error("expected panic for duplicate event registration")
-		}
-	}()
-	rtr := router.New()
-	rtr.On("ping", func(_ *router.Context) {})
-	rtr.On("ping", func(_ *router.Context) {})
+	require.Panics(t, func() {
+		rtr := router.New()
+		rtr.On("ping", func(_ *router.Context) {})
+		rtr.On("ping", func(_ *router.Context) {})
+	})
 }
 
 func TestRouter_On_PanicsOnNoHandlers(t *testing.T) {
-	defer func() {
-		if recover() == nil {
-			t.Error("expected panic when On called with no handlers")
-		}
-	}()
-	rtr := router.New()
-	rtr.On("ping")
+	require.Panics(t, func() {
+		rtr := router.New()
+		rtr.On("ping")
+	})
 }
 
 func TestRouter_On_PanicsOnNilHandler(t *testing.T) {
-	defer func() {
-		if recover() == nil {
-			t.Error("expected panic when On called with nil handler")
-		}
-	}()
-	rtr := router.New()
-	rtr.On("ping", nil)
+	require.Panics(t, func() {
+		rtr := router.New()
+		rtr.On("ping", nil)
+	})
 }
 
 func TestRouter_Use_PanicsOnNilHandler(t *testing.T) {
-	defer func() {
-		if recover() == nil {
-			t.Error("expected panic when Use called with nil handler")
-		}
-	}()
-	rtr := router.New()
-	rtr.Use(nil)
+	require.Panics(t, func() {
+		rtr := router.New()
+		rtr.Use(nil)
+	})
 }
 
 func TestRouter_CombineHandlers_PanicsWhenChainTooLong(t *testing.T) {
 	defer func() {
-		err := recover()
-		if err == nil {
-			t.Error("expected panic for oversized handler chain")
-			return
-		}
-		msg, ok := err.(string)
-		if !ok {
-			t.Errorf("expected string panic, got %T: %v", err, err)
-			return
-		}
-		if !strings.Contains(msg, "exceeds maximum") {
-			t.Errorf("panic message %q does not mention exceeds maximum", msg)
-		}
+		r := recover()
+		require.NotNil(t, r, "expected panic for oversized handler chain")
+		msg, ok := r.(string)
+		require.True(t, ok, "expected string panic, got %T: %v", r, r)
+		assert.Contains(t, msg, "exceeds maximum")
 	}()
 
 	rtr := router.New()

--- a/transport.go
+++ b/transport.go
@@ -3,7 +3,7 @@ package wspulse
 import "time"
 
 // Transport abstracts the WebSocket connection for testability.
-// *gorilla/websocket.Conn satisfies this interface via duck typing —
+// gorilla/websocket.Conn satisfies this interface via duck typing —
 // no wrapper or adapter is needed in production code.
 type Transport interface {
 	// ReadMessage reads a complete message from the connection.

--- a/transport.go
+++ b/transport.go
@@ -1,0 +1,33 @@
+package wspulse
+
+import "time"
+
+// Transport abstracts the WebSocket connection for testability.
+// *gorilla/websocket.Conn satisfies this interface via duck typing —
+// no wrapper or adapter is needed in production code.
+type Transport interface {
+	// ReadMessage reads a complete message from the connection.
+	ReadMessage() (messageType int, p []byte, err error)
+
+	// WriteMessage writes a complete message to the connection.
+	WriteMessage(messageType int, data []byte) error
+
+	// SetReadLimit sets the maximum size in bytes for a message read
+	// from the connection.
+	SetReadLimit(limit int64)
+
+	// SetReadDeadline sets the read deadline on the underlying
+	// network connection.
+	SetReadDeadline(t time.Time) error
+
+	// SetWriteDeadline sets the write deadline on the underlying
+	// network connection.
+	SetWriteDeadline(t time.Time) error
+
+	// SetPongHandler sets the handler for pong messages received
+	// from the peer.
+	SetPongHandler(h func(appData string) error)
+
+	// Close closes the underlying network connection.
+	Close() error
+}

--- a/transport.go
+++ b/transport.go
@@ -7,9 +7,12 @@ import "time"
 // no wrapper or adapter is needed in production code.
 type Transport interface {
 	// ReadMessage reads a complete message from the connection.
+	// The returned messageType is TextMessage (1) or BinaryMessage (2).
 	ReadMessage() (messageType int, p []byte, err error)
 
 	// WriteMessage writes a complete message to the connection.
+	// messageType should be TextMessage (1) or BinaryMessage (2),
+	// consistent with Codec.FrameType.
 	WriteMessage(messageType int, data []byte) error
 
 	// SetReadLimit sets the maximum size in bytes for a message read


### PR DESCRIPTION
## Summary

Merge develop branch to main for v0.3.0 release preparation. Includes Transport interface and testify adoption.

## Changes

- Added `Transport` interface (`transport.go`) — abstracts WebSocket connection for testability
- Adopted `testify` for test assertions
- Updated documentation: README, copilot-instructions, AGENTS.md
- Dependency policy clarified: zero production deps, test deps permitted

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR