### PR TITLE
Release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+---
+
+## [0.3.1] - 2026-04-04
+
+### Changed
+
+- `Transport` GoDoc now documents the comparability requirement — implementations must be comparable (`==` / `!=`) because the server uses interface equality to detect stale transports
+
+---
+
+## [0.3.0] - 2026-04-02
+
 ### Added
 
 - `Transport` interface — abstracts WebSocket connection for testability. `*gorilla/websocket.Conn` satisfies it via duck typing.
@@ -41,6 +53,8 @@
 - `TextMessage` (1) and `BinaryMessage` (2) WebSocket frame type constants
 - `ErrConnectionClosed` and `ErrSendBufferFull` sentinel errors
 
-[Unreleased]: https://github.com/wspulse/core/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/wspulse/core/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/wspulse/core/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/wspulse/core/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/wspulse/core/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/wspulse/core/releases/tag/v0.1.0

--- a/transport.go
+++ b/transport.go
@@ -5,6 +5,10 @@ import "time"
 // Transport abstracts the WebSocket connection for testability.
 // gorilla/websocket.Conn satisfies this interface via duck typing —
 // no wrapper or adapter is needed in production code.
+//
+// Implementations must be comparable (== / !=). The server uses interface
+// equality to detect stale transport-died notifications. Pointer receiver
+// types satisfy this requirement naturally.
 type Transport interface {
 	// ReadMessage reads a complete message from the connection.
 	// The returned messageType is TextMessage (1) or BinaryMessage (2).


### PR DESCRIPTION
## Summary

Release v0.3.1: document Transport comparability requirement in GoDoc.

## Changes

- `Transport` interface GoDoc now states implementations must be comparable (`==` / `!=`) — the server uses interface equality to detect stale transport-died notifications

## Checklist

- [x] CHANGELOG updated
- [x] `make check` passes
- [x] No breaking changes (documentation only)