### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,9 +6,9 @@ wspulse/core provides the **shared types** used across the wspulse WebSocket eco
 
 ## Architecture
 
-- **`frame.go`** — `Frame` struct (the minimal transport unit), WebSocket message type constants (`TextMessage`, `BinaryMessage`), and shared sentinel errors (`ErrConnectionClosed`, `ErrSendBufferFull`).
+- **`frame.go`** — `Frame` struct (the minimal transport unit) and shared sentinel errors (`ErrConnectionClosed`, `ErrSendBufferFull`).
 - **`codec.go`** — `Codec` interface (`Encode`, `Decode`, `FrameType`), default `JSONCodec` implementation, and the unexported `wireFrame`/`jsonCodec` types.
-- **`transport.go`** — `Transport` interface abstracting WebSocket connections for testability. `*gorilla/websocket.Conn` satisfies it via duck typing.
+- **`transport.go`** — `Transport` interface abstracting WebSocket connections for testability. `MessageType` and `StatusCode` typed constants (RFC 6455 values matching coder/websocket and gorilla/websocket). Consuming modules wrap `*coder/websocket.Conn` in a thin adapter.
 - **`router/`** — Gin-style event router (`Router`, `Context`, `Connection`, `HandlerFunc`, `Recovery`). Dispatches inbound `Frame` values by `Frame.Event` through a global middleware + per-event handler chain. Lazy chain building, `sync.Pool`-backed `Context` recycling, atomic fast path for steady-state dispatches.
 
 ## Development Workflow

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -65,6 +65,32 @@ All new features and design changes follow this process — do not skip steps:
 6. **Design discussion** — API surface, cross-SDK parity, contract/protocol updates, edge cases
 7. **Task** — feature branch from `develop`, implement with tests, CHANGELOG entry, PR following template. **Repo-scoped**: link PR to the issue. **Global**: each PR mentions the global issue (e.g., `wspulse/.github#N`); after opening a PR, comment on the global issue with the PR link
 
+## Release Workflow
+
+Releases follow a branch-based process. A CI changelog-gate enforces CHANGELOG hygiene before merge to `main`.
+
+1. **Feature work** lands on `develop` via PRs (each PR must include a CHANGELOG entry under `[Unreleased]`).
+2. **Prepare** — create a `chore/release-vX.Y.Z` branch from `develop`:
+   ```bash
+   git checkout develop && git pull
+   git checkout -b chore/release-vX.Y.Z
+   ```
+3. **Update CHANGELOG** — promote `[Unreleased]` to a concrete version and date. Remove the empty `## [Unreleased]` section entirely — the CI gate rejects it:
+   ```markdown
+   ## [X.Y.Z] - YYYY-MM-DD
+   ```
+   Also add the comparison link at the bottom:
+   ```markdown
+   [X.Y.Z]: https://github.com/wspulse/<repo>/compare/vPREV...vX.Y.Z
+   ```
+4. **Open PR** — `chore/release-vX.Y.Z` → `main`. The CI changelog-gate checks that the top `## [` entry in CHANGELOG.md is not `[Unreleased]`.
+5. **After merge** — tag the release on `main`:
+   ```bash
+   git checkout main && git pull
+   git tag vX.Y.Z && git push origin vX.Y.Z
+   ```
+6. **Sync develop** — merge `main` back into `develop` to pick up the release commit.
+
 ## Critical Rules
 
 1. **Read before write** — always read the target file and relevant docs fully before editing.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -65,32 +65,6 @@ All new features and design changes follow this process — do not skip steps:
 6. **Design discussion** — API surface, cross-SDK parity, contract/protocol updates, edge cases
 7. **Task** — feature branch from `develop`, implement with tests, CHANGELOG entry, PR following template. **Repo-scoped**: link PR to the issue. **Global**: each PR mentions the global issue (e.g., `wspulse/.github#N`); after opening a PR, comment on the global issue with the PR link
 
-## Release Workflow
-
-Releases follow a branch-based process. A CI changelog-gate enforces CHANGELOG hygiene before merge to `main`.
-
-1. **Feature work** lands on `develop` via PRs (each PR must include a CHANGELOG entry under `[Unreleased]`).
-2. **Prepare** — create a `chore/release-vX.Y.Z` branch from `develop`:
-   ```bash
-   git checkout develop && git pull
-   git checkout -b chore/release-vX.Y.Z
-   ```
-3. **Update CHANGELOG** — promote `[Unreleased]` to a concrete version and date. Remove the empty `## [Unreleased]` section entirely — the CI gate rejects it:
-   ```markdown
-   ## [X.Y.Z] - YYYY-MM-DD
-   ```
-   Also add the comparison link at the bottom:
-   ```markdown
-   [X.Y.Z]: https://github.com/wspulse/<repo>/compare/vPREV...vX.Y.Z
-   ```
-4. **Open PR** — `chore/release-vX.Y.Z` → `main`. The CI changelog-gate checks that the top `## [` entry in CHANGELOG.md is not `[Unreleased]`.
-5. **After merge** — tag the release on `main`:
-   ```bash
-   git checkout main && git pull
-   git tag vX.Y.Z && git push origin vX.Y.Z
-   ```
-6. **Sync develop** — merge `main` back into `develop` to pick up the release commit.
-
 ## Critical Rules
 
 1. **Read before write** — always read the target file and relevant docs fully before editing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 - `Frame` struct with `ID string`, `Type string`, and `Payload []byte` fields
 - `Codec` interface: `Encode(Frame) ([]byte, error)`, `Decode([]byte) (Frame, error)`, `FrameType() int`
 - `JSONCodec` default implementation — JSON text frames, zero external dependencies
-- `TextMessage` (1) and `BinaryMessage` (2) WebSocket frame type constants
+- `MessageText` (1) and `MessageBinary` (2) WebSocket frame type constants on the new `MessageType` type
 - `ErrConnectionClosed` and `ErrSendBufferFull` sentinel errors
 
 [Unreleased]: https://github.com/wspulse/core/compare/v0.3.1...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- `MessageType` named type (`int`) for WebSocket frame types; constants `TextMessage` (1) and `BinaryMessage` (2)
+- `MessageType` named type (`int`) for WebSocket frame types
 - `StatusCode` named type (`int`) for WebSocket close status codes; constants `StatusNormalClosure` (1000), `StatusGoingAway` (1001), `StatusAbnormalClosure` (1006)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## [Unreleased]
-
----
-
 ## [0.4.0] - 2026-04-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - **BREAKING**: `Transport` interface redesigned with a context-based API. Removed `SetReadDeadline`, `SetWriteDeadline`, `SetPongHandler`, `ReadMessage`, `WriteMessage`. Added `Read(ctx)`, `Write(ctx, typ, data)`, `Ping(ctx)`, `Close(code, reason)`, `CloseNow`. `SetReadLimit` retained unchanged. Consuming modules must wrap `*coder/websocket.Conn` in a thin adapter.
 - **BREAKING**: `TextMessage` and `BinaryMessage` changed from untyped `int` to the new `MessageType` type. Values are unchanged (1 and 2).
+- **BREAKING**: `Codec.FrameType()` now returns `MessageType` instead of `int`. Update any custom `Codec` implementations accordingly.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@
 ### Added
 
 - `Transport` interface — abstracts WebSocket connection for testability with a context-based API
-- `MessageType` named type (`int`) for WebSocket frame types; constants `MessageText` (1) and `MessageBinary` (2)
+- `MessageType` named type (`int`) for WebSocket frame types; constants `TextMessage` (1) and `BinaryMessage` (2)
 - `StatusCode` named type (`int`) for WebSocket close status codes; constants `StatusNormalClosure` (1000), `StatusGoingAway` (1001), `StatusAbnormalClosure` (1006)
 
 ### Removed
 
-- **BREAKING**: Untyped int constants `TextMessage` and `BinaryMessage` replaced by `MessageText` and `MessageBinary` on the new `MessageType` type
+- **BREAKING**: `TextMessage` and `BinaryMessage` are now typed as `MessageType` instead of untyped int
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+---
+
+## [0.4.0] - 2026-04-11
+
 ### Added
 
 - `MessageType` named type (`int`) for WebSocket frame types
@@ -59,7 +63,8 @@
 - `TextMessage` (1) and `BinaryMessage` (2) untyped int constants for WebSocket frame types
 - `ErrConnectionClosed` and `ErrSendBufferFull` sentinel errors
 
-[Unreleased]: https://github.com/wspulse/core/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/wspulse/core/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/wspulse/core/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/wspulse/core/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/wspulse/core/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/wspulse/core/compare/v0.1.0...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Changed
 
-- **BREAKING**: `Transport` interface redesigned with a context-based API. Removed `SetReadDeadline`, `SetWriteDeadline`, `SetPongHandler`, `ReadMessage`, `WriteMessage`. Added `Read(ctx)`, `Write(ctx, typ, data)`, `Ping(ctx)`, `SetReadLimit`, `Close(code, reason)`, `CloseNow`. Consuming modules must wrap `*coder/websocket.Conn` in a thin adapter.
+- **BREAKING**: `Transport` interface redesigned with a context-based API. Removed `SetReadDeadline`, `SetWriteDeadline`, `SetPongHandler`, `ReadMessage`, `WriteMessage`. Added `Read(ctx)`, `Write(ctx, typ, data)`, `Ping(ctx)`, `Close(code, reason)`, `CloseNow`. `SetReadLimit` retained unchanged. Consuming modules must wrap `*coder/websocket.Conn` in a thin adapter.
 - **BREAKING**: `TextMessage` and `BinaryMessage` changed from untyped `int` to the new `MessageType` type. Values are unchanged (1 and 2).
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Added
+
+- `Transport` interface — abstracts WebSocket connection for testability with a context-based API
+- `MessageType` named type (`int`) for WebSocket frame types; constants `MessageText` (1) and `MessageBinary` (2)
+- `StatusCode` named type (`int`) for WebSocket close status codes; constants `StatusNormalClosure` (1000), `StatusGoingAway` (1001), `StatusAbnormalClosure` (1006)
+
+### Removed
+
+- **BREAKING**: Untyped int constants `TextMessage` and `BinaryMessage` replaced by `MessageText` and `MessageBinary` on the new `MessageType` type
+
 ---
 
 ## [0.3.1] - 2026-04-04
@@ -13,10 +23,6 @@
 ---
 
 ## [0.3.0] - 2026-04-02
-
-### Added
-
-- `Transport` interface — abstracts WebSocket connection for testability. `*gorilla/websocket.Conn` satisfies it via duck typing.
 
 ### Removed
 
@@ -50,7 +56,7 @@
 - `Frame` struct with `ID string`, `Type string`, and `Payload []byte` fields
 - `Codec` interface: `Encode(Frame) ([]byte, error)`, `Decode([]byte) (Frame, error)`, `FrameType() int`
 - `JSONCodec` default implementation — JSON text frames, zero external dependencies
-- `MessageText` (1) and `MessageBinary` (2) WebSocket frame type constants on the new `MessageType` type
+- `TextMessage` (1) and `BinaryMessage` (2) untyped int constants for WebSocket frame types
 - `ErrConnectionClosed` and `ErrSendBufferFull` sentinel errors
 
 [Unreleased]: https://github.com/wspulse/core/compare/v0.3.1...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
 
 ## [0.3.0] - 2026-04-02
 
+### Added
+
+- `Transport` interface — abstracts WebSocket connection for testability. `*gorilla/websocket.Conn` satisfies it via duck typing.
+
 ### Removed
 
 - **BREAKING**: `Frame.ID` field removed — transport layer does not use it. Applications needing message IDs should use Payload.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 ### Added
 
-- `Transport` interface — abstracts WebSocket connection for testability with a context-based API
 - `MessageType` named type (`int`) for WebSocket frame types; constants `TextMessage` (1) and `BinaryMessage` (2)
 - `StatusCode` named type (`int`) for WebSocket close status codes; constants `StatusNormalClosure` (1000), `StatusGoingAway` (1001), `StatusAbnormalClosure` (1006)
 
-### Removed
+### Changed
 
-- **BREAKING**: `TextMessage` and `BinaryMessage` are now typed as `MessageType` instead of untyped int
+- **BREAKING**: `Transport` interface redesigned with a context-based API. Removed `SetReadDeadline`, `SetWriteDeadline`, `SetPongHandler`, `ReadMessage`, `WriteMessage`. Added `Read(ctx)`, `Write(ctx, typ, data)`, `Ping(ctx)`, `SetReadLimit`, `Close(code, reason)`, `CloseNow`. Consuming modules must wrap `*coder/websocket.Conn` in a thin adapter.
+- **BREAKING**: `TextMessage` and `BinaryMessage` changed from untyped `int` to the new `MessageType` type. Values are unchanged (1 and 2).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ if err != nil {
 fmt.Println(decoded.Event) // "msg"
 
 // Check the codec's WebSocket frame type
-wspulse.JSONCodec.FrameType() // int(wspulse.MessageText) == 1
+wspulse.JSONCodec.FrameType() // returns 1 (MessageText)
 ```
 
 ### Sentinel errors

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ if err != nil {
 fmt.Println(decoded.Event) // "msg"
 
 // Check the codec's WebSocket frame type
-wspulse.JSONCodec.FrameType() // returns 1 (MessageText)
+wspulse.JSONCodec.FrameType() // returns 1 (TextMessage)
 ```
 
 ### Sentinel errors

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ if err != nil {
 fmt.Println(decoded.Event) // "msg"
 
 // Check the codec's WebSocket frame type
-wspulse.JSONCodec.FrameType() // wspulse.TextMessage (1)
+wspulse.JSONCodec.FrameType() // int(wspulse.MessageText) == 1
 ```
 
 ### Sentinel errors

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ if err != nil {
 fmt.Println(decoded.Event) // "msg"
 
 // Check the codec's WebSocket frame type
-wspulse.JSONCodec.FrameType() // returns 1 (TextMessage)
+wspulse.JSONCodec.FrameType() // returns wspulse.TextMessage
 ```
 
 ### Sentinel errors

--- a/codec.go
+++ b/codec.go
@@ -12,7 +12,7 @@ type Codec interface {
 
 	// FrameType returns the WebSocket message type to use when sending.
 	// The returned int matches the value of MessageType constants
-	// (MessageText (1), MessageBinary (2)). Consuming modules cast to
+	// (TextMessage (1), BinaryMessage (2)). Consuming modules cast to
 	// MessageType at the adapter boundary.
 	FrameType() int
 }
@@ -32,7 +32,7 @@ type jsonCodec struct{}
 // Frame.Payload must be valid JSON bytes (e.g. the output of json.Marshal).
 var JSONCodec Codec = jsonCodec{}
 
-func (jsonCodec) FrameType() int { return int(MessageText) }
+func (jsonCodec) FrameType() int { return int(TextMessage) }
 
 func (jsonCodec) Encode(f Frame) ([]byte, error) {
 	return json.Marshal(wireFrame{

--- a/codec.go
+++ b/codec.go
@@ -11,9 +11,9 @@ type Codec interface {
 	Decode(data []byte) (Frame, error)
 
 	// FrameType returns the WebSocket message type to use when sending.
-	// The returned int matches the MessageType constants (MessageText = 1,
-	// MessageBinary = 2). Consuming modules cast to MessageType at the
-	// adapter boundary.
+	// The returned int matches the value of MessageType constants
+	// (MessageText (1), MessageBinary (2)). Consuming modules cast to
+	// MessageType at the adapter boundary.
 	FrameType() int
 }
 

--- a/codec.go
+++ b/codec.go
@@ -10,8 +10,10 @@ type Codec interface {
 	// Decode deserializes received WebSocket bytes into a Frame.
 	Decode(data []byte) (Frame, error)
 
-	// FrameType returns the WebSocket message type to use when sending:
-	// TextMessage (1) or BinaryMessage (2).
+	// FrameType returns the WebSocket message type to use when sending.
+	// The returned int matches the MessageType constants (MessageText = 1,
+	// MessageBinary = 2). Consuming modules cast to MessageType at the
+	// adapter boundary.
 	FrameType() int
 }
 
@@ -30,7 +32,7 @@ type jsonCodec struct{}
 // Frame.Payload must be valid JSON bytes (e.g. the output of json.Marshal).
 var JSONCodec Codec = jsonCodec{}
 
-func (jsonCodec) FrameType() int { return TextMessage }
+func (jsonCodec) FrameType() int { return int(MessageText) }
 
 func (jsonCodec) Encode(f Frame) ([]byte, error) {
 	return json.Marshal(wireFrame{

--- a/codec.go
+++ b/codec.go
@@ -11,10 +11,7 @@ type Codec interface {
 	Decode(data []byte) (Frame, error)
 
 	// FrameType returns the WebSocket message type to use when sending.
-	// The returned int matches the value of MessageType constants
-	// (TextMessage (1), BinaryMessage (2)). Consuming modules cast to
-	// MessageType at the adapter boundary.
-	FrameType() int
+	FrameType() MessageType
 }
 
 // wireFrame is the JSON on-the-wire representation of a Frame.
@@ -32,7 +29,7 @@ type jsonCodec struct{}
 // Frame.Payload must be valid JSON bytes (e.g. the output of json.Marshal).
 var JSONCodec Codec = jsonCodec{}
 
-func (jsonCodec) FrameType() int { return int(TextMessage) }
+func (jsonCodec) FrameType() MessageType { return TextMessage }
 
 func (jsonCodec) Encode(f Frame) ([]byte, error) {
 	return json.Marshal(wireFrame{

--- a/codec_test.go
+++ b/codec_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestJSONCodec_FrameType_IsTextMessage(t *testing.T) {
-	assert.Equal(t, int(wspulse.TextMessage), wspulse.JSONCodec.FrameType())
+	assert.Equal(t, wspulse.TextMessage, wspulse.JSONCodec.FrameType())
 }
 
 func TestJSONCodec_Encode_ProducesValidJSON(t *testing.T) {

--- a/codec_test.go
+++ b/codec_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestJSONCodec_FrameType_IsTextMessage(t *testing.T) {
-	assert.Equal(t, int(wspulse.MessageText), wspulse.JSONCodec.FrameType())
+	assert.Equal(t, int(wspulse.TextMessage), wspulse.JSONCodec.FrameType())
 }
 
 func TestJSONCodec_Encode_ProducesValidJSON(t *testing.T) {

--- a/codec_test.go
+++ b/codec_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestJSONCodec_FrameType_IsTextMessage(t *testing.T) {
-	assert.Equal(t, wspulse.TextMessage, wspulse.JSONCodec.FrameType())
+	assert.Equal(t, int(wspulse.MessageText), wspulse.JSONCodec.FrameType())
 }
 
 func TestJSONCodec_Encode_ProducesValidJSON(t *testing.T) {

--- a/frame.go
+++ b/frame.go
@@ -2,17 +2,6 @@ package wspulse
 
 import "errors"
 
-// WebSocket message type constants.
-// These mirror the standard WebSocket frame types without importing gorilla/websocket,
-// keeping this module free of external dependencies.
-const (
-	// TextMessage denotes a UTF-8 encoded text WebSocket frame (opcode 1).
-	TextMessage = 1
-
-	// BinaryMessage denotes a binary WebSocket frame (opcode 2).
-	BinaryMessage = 2
-)
-
 // Frame is the minimal transport unit for all WebSocket communication.
 // Payload bytes are opaque to the wspulse layer; their format depends on the Codec in use.
 // When using JSONCodec (the default), Payload must be valid JSON bytes (e.g. output of

--- a/frame_test.go
+++ b/frame_test.go
@@ -53,8 +53,8 @@ func TestSentinelErrors_HaveNonEmptyMessages(t *testing.T) {
 }
 
 func TestMessageTypeConstants(t *testing.T) {
-	assert.Equal(t, 1, wspulse.TextMessage)
-	assert.Equal(t, 2, wspulse.BinaryMessage)
+	assert.Equal(t, wspulse.MessageType(1), wspulse.MessageText)
+	assert.Equal(t, wspulse.MessageType(2), wspulse.MessageBinary)
 }
 
 func TestWireFrame_EmptyPayload_OmittedFromJSON(t *testing.T) {

--- a/frame_test.go
+++ b/frame_test.go
@@ -57,6 +57,12 @@ func TestMessageTypeConstants(t *testing.T) {
 	assert.Equal(t, wspulse.MessageType(2), wspulse.MessageBinary)
 }
 
+func TestStatusCodeConstants(t *testing.T) {
+	assert.Equal(t, wspulse.StatusCode(1000), wspulse.StatusNormalClosure)
+	assert.Equal(t, wspulse.StatusCode(1001), wspulse.StatusGoingAway)
+	assert.Equal(t, wspulse.StatusCode(1006), wspulse.StatusAbnormalClosure)
+}
+
 func TestWireFrame_EmptyPayload_OmittedFromJSON(t *testing.T) {
 	f := wspulse.Frame{Event: "ping"}
 	data, err := wspulse.JSONCodec.Encode(f)

--- a/frame_test.go
+++ b/frame_test.go
@@ -52,17 +52,6 @@ func TestSentinelErrors_HaveNonEmptyMessages(t *testing.T) {
 	}
 }
 
-func TestMessageTypeConstants(t *testing.T) {
-	assert.Equal(t, wspulse.MessageType(1), wspulse.TextMessage)
-	assert.Equal(t, wspulse.MessageType(2), wspulse.BinaryMessage)
-}
-
-func TestStatusCodeConstants(t *testing.T) {
-	assert.Equal(t, wspulse.StatusCode(1000), wspulse.StatusNormalClosure)
-	assert.Equal(t, wspulse.StatusCode(1001), wspulse.StatusGoingAway)
-	assert.Equal(t, wspulse.StatusCode(1006), wspulse.StatusAbnormalClosure)
-}
-
 func TestWireFrame_EmptyPayload_OmittedFromJSON(t *testing.T) {
 	f := wspulse.Frame{Event: "ping"}
 	data, err := wspulse.JSONCodec.Encode(f)

--- a/frame_test.go
+++ b/frame_test.go
@@ -53,8 +53,8 @@ func TestSentinelErrors_HaveNonEmptyMessages(t *testing.T) {
 }
 
 func TestMessageTypeConstants(t *testing.T) {
-	assert.Equal(t, wspulse.MessageType(1), wspulse.MessageText)
-	assert.Equal(t, wspulse.MessageType(2), wspulse.MessageBinary)
+	assert.Equal(t, wspulse.MessageType(1), wspulse.TextMessage)
+	assert.Equal(t, wspulse.MessageType(2), wspulse.BinaryMessage)
 }
 
 func TestStatusCodeConstants(t *testing.T) {

--- a/transport.go
+++ b/transport.go
@@ -75,6 +75,8 @@ type Transport interface {
 	// block indefinitely. The reference implementation (github.com/coder/websocket)
 	// applies a 5 s write timeout for the close frame and waits up to 5 s for
 	// the peer's response.
+	// Callers must not pass StatusAbnormalClosure — it is reserved for local
+	// error classification and is not a valid on-wire close code.
 	Close(code StatusCode, reason string) error
 
 	// CloseNow closes the underlying connection immediately without

--- a/transport.go
+++ b/transport.go
@@ -62,11 +62,15 @@ type Transport interface {
 	Ping(ctx context.Context) error
 
 	// SetReadLimit sets the maximum size in bytes for a single message read
-	// from the connection. Frames exceeding this limit are rejected.
+	// from the connection. Messages exceeding this limit are rejected.
 	SetReadLimit(n int64)
 
 	// Close performs the WebSocket close handshake with the given status code
 	// and reason, then closes the underlying connection.
+	// Implementations must enforce a bounded internal timeout — they must not
+	// block indefinitely. The reference implementation (github.com/coder/websocket)
+	// applies a 5 s write timeout for the close frame and waits up to 5 s for
+	// the peer's response.
 	Close(code StatusCode, reason string) error
 
 	// CloseNow closes the underlying connection immediately without

--- a/transport.go
+++ b/transport.go
@@ -4,7 +4,8 @@ import "context"
 
 // MessageType indicates the WebSocket message type of a frame.
 // Values follow RFC 6455 §11.8 and match those used by github.com/coder/websocket
-// and gorilla/websocket — no conversion is required at module boundaries.
+// and gorilla/websocket — numeric values are identical, so only a type cast is
+// needed at module boundaries (no runtime calculation).
 type MessageType int
 
 const (
@@ -16,8 +17,9 @@ const (
 )
 
 // StatusCode is a WebSocket close status code as defined by RFC 6455 §7.4.
-// Values match those used by github.com/coder/websocket — no conversion is
-// required at module boundaries.
+// Values match those used by github.com/coder/websocket — numeric values are
+// identical, so only a type cast is needed at module boundaries (no runtime
+// calculation).
 type StatusCode int
 
 // WebSocket close status codes from RFC 6455 §7.4.

--- a/transport.go
+++ b/transport.go
@@ -2,10 +2,11 @@ package wspulse
 
 import "context"
 
-// MessageType indicates the WebSocket message type of a frame.
-// Values follow RFC 6455 §11.8 and match those used by github.com/coder/websocket
-// and gorilla/websocket — numeric values are identical, so only a type cast is
-// needed at module boundaries (no runtime calculation).
+// MessageType indicates the WebSocket message type used in Transport read and
+// write operations. Values follow RFC 6455 §11.8 and match those used by
+// github.com/coder/websocket and gorilla/websocket — numeric values are
+// identical, so only a type cast is needed at module boundaries (no runtime
+// calculation).
 type MessageType int
 
 const (
@@ -32,8 +33,9 @@ const (
 	StatusGoingAway StatusCode = 1001
 
 	// StatusAbnormalClosure indicates a connection closed without a close frame,
-	// e.g. an abrupt TCP drop (1006). This code is never sent in a real close frame;
-	// it is used only for local error classification.
+	// e.g. an abrupt TCP drop (1006). RFC 6455 reserves this code for local error
+	// classification only — implementations must not include it in close frames
+	// sent to the peer.
 	StatusAbnormalClosure StatusCode = 1006
 )
 

--- a/transport.go
+++ b/transport.go
@@ -1,40 +1,75 @@
 package wspulse
 
-import "time"
+import "context"
+
+// MessageType indicates the WebSocket message type of a frame.
+// Values follow RFC 6455 §11.8 and match those used by github.com/coder/websocket
+// and gorilla/websocket — no conversion is required at module boundaries.
+type MessageType int
+
+const (
+	// MessageText denotes a UTF-8 encoded text frame (opcode 1).
+	MessageText MessageType = 1
+
+	// MessageBinary denotes a binary frame (opcode 2).
+	MessageBinary MessageType = 2
+)
+
+// StatusCode is a WebSocket close status code as defined by RFC 6455 §7.4.
+// Values match those used by github.com/coder/websocket — no conversion is
+// required at module boundaries.
+type StatusCode int
+
+// WebSocket close status codes from RFC 6455 §7.4.
+const (
+	// StatusNormalClosure indicates a normal, intentional close (1000).
+	StatusNormalClosure StatusCode = 1000
+
+	// StatusGoingAway indicates the endpoint is going away, e.g. server shutdown
+	// or browser tab close (1001).
+	StatusGoingAway StatusCode = 1001
+
+	// StatusAbnormalClosure indicates a connection closed without a close frame,
+	// e.g. an abrupt TCP drop (1006). This code is never sent in a real close frame;
+	// it is used only for local error classification.
+	StatusAbnormalClosure StatusCode = 1006
+)
 
 // Transport abstracts the WebSocket connection for testability.
-// gorilla/websocket.Conn satisfies this interface via duck typing —
-// no wrapper or adapter is needed in production code.
+// The API is context-based: deadlines are expressed via context cancellation
+// rather than explicit SetReadDeadline / SetWriteDeadline calls.
 //
-// Implementations must be comparable (== / !=). The server uses interface
+// *github.com/coder/websocket.Conn does not satisfy this interface directly;
+// each consuming module (hub, client-go) wraps it in a thin adapter that
+// converts between Transport's domain types and coder's native types.
+//
+// Implementations must be comparable (== / !=). The hub uses interface
 // equality to detect stale transport-died notifications. Pointer receiver
 // types satisfy this requirement naturally.
 type Transport interface {
-	// ReadMessage reads a complete message from the connection.
-	// The returned messageType is TextMessage (1) or BinaryMessage (2).
-	ReadMessage() (messageType int, p []byte, err error)
+	// Read reads the next message from the connection.
+	// Blocks until a message arrives, ctx is cancelled, or the connection closes.
+	Read(ctx context.Context) (MessageType, []byte, error)
 
-	// WriteMessage writes a complete message to the connection.
-	// messageType should be TextMessage (1) or BinaryMessage (2),
-	// consistent with Codec.FrameType.
-	WriteMessage(messageType int, data []byte) error
+	// Write sends a message to the connection.
+	// ctx may carry a deadline for the write operation.
+	Write(ctx context.Context, typ MessageType, data []byte) error
 
-	// SetReadLimit sets the maximum size in bytes for a message read
-	// from the connection.
-	SetReadLimit(limit int64)
+	// Ping sends a ping to the peer and waits for a pong.
+	// ctx may carry a deadline; if the pong does not arrive before the deadline,
+	// Ping returns an error and the connection should be considered dead.
+	// Must be called concurrently with Read.
+	Ping(ctx context.Context) error
 
-	// SetReadDeadline sets the read deadline on the underlying
-	// network connection.
-	SetReadDeadline(t time.Time) error
+	// SetReadLimit sets the maximum size in bytes for a single message read
+	// from the connection. Frames exceeding this limit are rejected.
+	SetReadLimit(n int64)
 
-	// SetWriteDeadline sets the write deadline on the underlying
-	// network connection.
-	SetWriteDeadline(t time.Time) error
+	// Close performs the WebSocket close handshake with the given status code
+	// and reason, then closes the underlying connection.
+	Close(code StatusCode, reason string) error
 
-	// SetPongHandler sets the handler for pong messages received
-	// from the peer.
-	SetPongHandler(h func(appData string) error)
-
-	// Close closes the underlying network connection.
-	Close() error
+	// CloseNow closes the underlying connection immediately without
+	// attempting a close handshake. Used in defer paths and error teardown.
+	CloseNow() error
 }

--- a/transport.go
+++ b/transport.go
@@ -10,11 +10,11 @@ import "context"
 type MessageType int
 
 const (
-	// MessageText denotes a UTF-8 encoded text frame (opcode 1).
-	MessageText MessageType = 1
+	// TextMessage denotes a UTF-8 encoded text frame (opcode 1).
+	TextMessage MessageType = 1
 
-	// MessageBinary denotes a binary frame (opcode 2).
-	MessageBinary MessageType = 2
+	// BinaryMessage denotes a binary frame (opcode 2).
+	BinaryMessage MessageType = 2
 )
 
 // StatusCode is a WebSocket close status code as defined by RFC 6455 §7.4.

--- a/transport_test.go
+++ b/transport_test.go
@@ -1,0 +1,20 @@
+package wspulse_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	wspulse "github.com/wspulse/core"
+)
+
+func TestMessageTypeConstants(t *testing.T) {
+	assert.Equal(t, wspulse.MessageType(1), wspulse.TextMessage)
+	assert.Equal(t, wspulse.MessageType(2), wspulse.BinaryMessage)
+}
+
+func TestStatusCodeConstants(t *testing.T) {
+	assert.Equal(t, wspulse.StatusCode(1000), wspulse.StatusNormalClosure)
+	assert.Equal(t, wspulse.StatusCode(1001), wspulse.StatusGoingAway)
+	assert.Equal(t, wspulse.StatusCode(1006), wspulse.StatusAbnormalClosure)
+}


### PR DESCRIPTION
## Summary

Release v0.4.0 — context-based Transport redesign for the coder/websocket migration. Part of wspulse/.github#32.

## Changes

- CHANGELOG: promote [Unreleased] to [0.4.0] - 2026-04-11

See [CHANGELOG.md](CHANGELOG.md) for full release notes.

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR