### PR TITLE
feat(codec): change FrameType() return type from int to MessageType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - **BREAKING**: `Transport` interface redesigned with a context-based API. Removed `SetReadDeadline`, `SetWriteDeadline`, `SetPongHandler`, `ReadMessage`, `WriteMessage`. Added `Read(ctx)`, `Write(ctx, typ, data)`, `Ping(ctx)`, `Close(code, reason)`, `CloseNow`. `SetReadLimit` retained unchanged. Consuming modules must wrap `*coder/websocket.Conn` in a thin adapter.
 - **BREAKING**: `TextMessage` and `BinaryMessage` changed from untyped `int` to the new `MessageType` type. Values are unchanged (1 and 2).
+- **BREAKING**: `Codec.FrameType()` now returns `MessageType` instead of `int`. Update any custom `Codec` implementations accordingly.
 
 ---
 
@@ -23,6 +24,10 @@
 ---
 
 ## [0.3.0] - 2026-04-02
+
+### Added
+
+- `Transport` interface — abstracts WebSocket connection for testability. `*gorilla/websocket.Conn` satisfies it via duck typing.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ if err != nil {
 fmt.Println(decoded.Event) // "msg"
 
 // Check the codec's WebSocket frame type
-wspulse.JSONCodec.FrameType() // returns 1 (TextMessage)
+wspulse.JSONCodec.FrameType() // returns wspulse.TextMessage
 ```
 
 ### Sentinel errors

--- a/codec.go
+++ b/codec.go
@@ -11,10 +11,7 @@ type Codec interface {
 	Decode(data []byte) (Frame, error)
 
 	// FrameType returns the WebSocket message type to use when sending.
-	// The returned int matches the value of MessageType constants
-	// (TextMessage (1), BinaryMessage (2)). Consuming modules cast to
-	// MessageType at the adapter boundary.
-	FrameType() int
+	FrameType() MessageType
 }
 
 // wireFrame is the JSON on-the-wire representation of a Frame.
@@ -32,7 +29,7 @@ type jsonCodec struct{}
 // Frame.Payload must be valid JSON bytes (e.g. the output of json.Marshal).
 var JSONCodec Codec = jsonCodec{}
 
-func (jsonCodec) FrameType() int { return int(TextMessage) }
+func (jsonCodec) FrameType() MessageType { return TextMessage }
 
 func (jsonCodec) Encode(f Frame) ([]byte, error) {
 	return json.Marshal(wireFrame{

--- a/codec_test.go
+++ b/codec_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestJSONCodec_FrameType_IsTextMessage(t *testing.T) {
-	assert.Equal(t, int(wspulse.TextMessage), wspulse.JSONCodec.FrameType())
+	assert.Equal(t, wspulse.TextMessage, wspulse.JSONCodec.FrameType())
 }
 
 func TestJSONCodec_Encode_ProducesValidJSON(t *testing.T) {


### PR DESCRIPTION
## Summary

`Codec.FrameType()` returns `MessageType` instead of `int`, eliminating the need for callers to cast and making the type contract self-documenting. Part of wspulse/.github#32.

## Related issues

Closes #31
Relates to wspulse/.github#32

## Changes

- **`Codec.FrameType()` return type**: `int` → `MessageType` (**breaking** — custom `Codec` implementations must update their signature)
- **`JSONCodec.FrameType()`**: returns `TextMessage` directly (no cast)
- **`codec_test.go`**: updated assertion to compare `MessageType` directly
- **`README.md`**: updated example comment to `// returns wspulse.TextMessage`
- **`CHANGELOG.md`**: added breaking change entry; restored v0.3.0 `Transport` Added entry that was accidentally removed in an earlier restructure

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] Breaking change: `Codec.FrameType()` signature change — v0, no stability guarantee
- [x] New public API changes have GoDoc comments