### PR TITLE
feat(transport): expand StatusCode to full RFC 6455 §7.4.1 set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `StatusCode` constants expanded to cover the full RFC 6455 §7.4.1 set: `StatusProtocolError` (1002), `StatusUnsupportedData` (1003), `StatusNoStatusReceived` (1005), `StatusInvalidFramePayloadData` (1007), `StatusPolicyViolation` (1008), `StatusMessageTooBig` (1009), `StatusMandatoryExtension` (1010), `StatusInternalError` (1011), `StatusTLSHandshake` (1015). Local-only codes (1005, 1006, 1015) are documented as MUST NOT be sent in a close frame.
+
+---
+
 ## [0.4.0] - 2026-04-11
 
 ### Added

--- a/transport.go
+++ b/transport.go
@@ -23,17 +23,8 @@ const (
 // calculation).
 type StatusCode int
 
-// WebSocket close status codes from RFC 6455 §7.4.
-//
-// Codes are grouped by whether they may appear in a WebSocket close frame sent
-// to the peer:
-//
-//   - Standard codes (1000–1003, 1007–1011): valid on the wire; pass to Close.
-//   - Local-only codes (1005, 1006, 1015): RFC 6455 §7.4.1 explicitly reserves
-//     these for local use. They MUST NOT be sent in a close frame. They are
-//     exposed here solely for classifying locally observed error conditions
-//     (e.g. logging, metrics, internal routing). Passing them to Close will
-//     result in a protocol violation.
+// Standard WebSocket close status codes from RFC 6455 §7.4.1.
+// These are valid on the wire — safe to pass to Transport.Close.
 const (
 	// StatusNormalClosure indicates a normal, intentional close (1000).
 	StatusNormalClosure StatusCode = 1000
@@ -46,25 +37,11 @@ const (
 	StatusProtocolError StatusCode = 1002
 
 	// StatusUnsupportedData indicates the received data type cannot be handled,
-	// e.g. a text frame containing non-UTF-8 bytes (1003).
+	// e.g. a binary frame sent to an endpoint that only accepts text (1003).
 	StatusUnsupportedData StatusCode = 1003
 
-	// StatusNoStatusReceived indicates a connection closed without a close frame
-	// containing a status code (1005).
-	//
-	// LOCAL-ONLY — RFC 6455 §7.4.1: MUST NOT be sent in a close frame.
-	// Use only for local error classification (logging, metrics).
-	StatusNoStatusReceived StatusCode = 1005
-
-	// StatusAbnormalClosure indicates a connection closed without a close frame,
-	// e.g. an abrupt TCP drop (1006).
-	//
-	// LOCAL-ONLY — RFC 6455 §7.4.1: MUST NOT be sent in a close frame.
-	// Use only for local error classification (logging, metrics).
-	StatusAbnormalClosure StatusCode = 1006
-
 	// StatusInvalidFramePayloadData indicates the received message contains data
-	// inconsistent with the message type, e.g. non-UTF-8 bytes in a text message
+	// inconsistent with the message type, e.g. non-UTF-8 bytes in a text frame
 	// (1007).
 	StatusInvalidFramePayloadData StatusCode = 1007
 
@@ -83,11 +60,21 @@ const (
 	// StatusInternalError indicates the server encountered an unexpected condition
 	// that prevented it from fulfilling the request (1011).
 	StatusInternalError StatusCode = 1011
+)
+
+// Local-only WebSocket close status codes from RFC 6455 §7.4.1.
+// These MUST NOT be sent in a close frame — do not pass them to Transport.Close.
+// Use them only to classify locally observed error conditions (logging, metrics).
+const (
+	// StatusNoStatusReceived indicates a close frame was received but contained
+	// no status code (1005).
+	StatusNoStatusReceived StatusCode = 1005
+
+	// StatusAbnormalClosure indicates the connection was closed without any close
+	// frame, e.g. an abrupt TCP drop (1006).
+	StatusAbnormalClosure StatusCode = 1006
 
 	// StatusTLSHandshake indicates a TLS handshake failure (1015).
-	//
-	// LOCAL-ONLY — RFC 6455 §7.4.1: MUST NOT be sent in a close frame.
-	// Use only for local error classification (logging, metrics).
 	StatusTLSHandshake StatusCode = 1015
 )
 
@@ -127,8 +114,9 @@ type Transport interface {
 	// block indefinitely. The reference implementation (github.com/coder/websocket)
 	// applies a 5 s write timeout for the close frame and waits up to 5 s for
 	// the peer's response.
-	// Callers must not pass StatusAbnormalClosure — it is reserved for local
-	// error classification and is not a valid on-wire close code.
+	// Callers must not pass local-only codes (StatusNoStatusReceived,
+	// StatusAbnormalClosure, StatusTLSHandshake) — doing so is a protocol
+	// violation. Use only the standard codes declared in the first const block.
 	Close(code StatusCode, reason string) error
 
 	// CloseNow closes the underlying connection immediately without

--- a/transport.go
+++ b/transport.go
@@ -24,6 +24,16 @@ const (
 type StatusCode int
 
 // WebSocket close status codes from RFC 6455 §7.4.
+//
+// Codes are grouped by whether they may appear in a WebSocket close frame sent
+// to the peer:
+//
+//   - Standard codes (1000–1003, 1007–1011): valid on the wire; pass to Close.
+//   - Local-only codes (1005, 1006, 1015): RFC 6455 §7.4.1 explicitly reserves
+//     these for local use. They MUST NOT be sent in a close frame. They are
+//     exposed here solely for classifying locally observed error conditions
+//     (e.g. logging, metrics, internal routing). Passing them to Close will
+//     result in a protocol violation.
 const (
 	// StatusNormalClosure indicates a normal, intentional close (1000).
 	StatusNormalClosure StatusCode = 1000
@@ -32,11 +42,53 @@ const (
 	// or browser tab close (1001).
 	StatusGoingAway StatusCode = 1001
 
+	// StatusProtocolError indicates a protocol error was detected (1002).
+	StatusProtocolError StatusCode = 1002
+
+	// StatusUnsupportedData indicates the received data type cannot be handled,
+	// e.g. a text frame containing non-UTF-8 bytes (1003).
+	StatusUnsupportedData StatusCode = 1003
+
+	// StatusNoStatusReceived indicates a connection closed without a close frame
+	// containing a status code (1005).
+	//
+	// LOCAL-ONLY — RFC 6455 §7.4.1: MUST NOT be sent in a close frame.
+	// Use only for local error classification (logging, metrics).
+	StatusNoStatusReceived StatusCode = 1005
+
 	// StatusAbnormalClosure indicates a connection closed without a close frame,
-	// e.g. an abrupt TCP drop (1006). RFC 6455 reserves this code for local error
-	// classification only — implementations must not include it in close frames
-	// sent to the peer.
+	// e.g. an abrupt TCP drop (1006).
+	//
+	// LOCAL-ONLY — RFC 6455 §7.4.1: MUST NOT be sent in a close frame.
+	// Use only for local error classification (logging, metrics).
 	StatusAbnormalClosure StatusCode = 1006
+
+	// StatusInvalidFramePayloadData indicates the received message contains data
+	// inconsistent with the message type, e.g. non-UTF-8 bytes in a text message
+	// (1007).
+	StatusInvalidFramePayloadData StatusCode = 1007
+
+	// StatusPolicyViolation indicates a message that violates an endpoint policy
+	// was received (1008).
+	StatusPolicyViolation StatusCode = 1008
+
+	// StatusMessageTooBig indicates the received message is too large to process
+	// (1009).
+	StatusMessageTooBig StatusCode = 1009
+
+	// StatusMandatoryExtension indicates the client expected the server to
+	// negotiate a required extension but the server did not (1010).
+	StatusMandatoryExtension StatusCode = 1010
+
+	// StatusInternalError indicates the server encountered an unexpected condition
+	// that prevented it from fulfilling the request (1011).
+	StatusInternalError StatusCode = 1011
+
+	// StatusTLSHandshake indicates a TLS handshake failure (1015).
+	//
+	// LOCAL-ONLY — RFC 6455 §7.4.1: MUST NOT be sent in a close frame.
+	// Use only for local error classification (logging, metrics).
+	StatusTLSHandshake StatusCode = 1015
 )
 
 // Transport abstracts the WebSocket connection for testability.

--- a/transport.go
+++ b/transport.go
@@ -53,8 +53,10 @@ const (
 	// (1009).
 	StatusMessageTooBig StatusCode = 1009
 
-	// StatusMandatoryExtension indicates the client expected the server to
-	// negotiate a required extension but the server did not (1010).
+	// StatusMandatoryExtension indicates the client required a WebSocket
+	// extension that the server did not negotiate (1010). Valid on the wire,
+	// but not used by the wspulse ecosystem — included for completeness when
+	// classifying close frames received from peers.
 	StatusMandatoryExtension StatusCode = 1010
 
 	// StatusInternalError indicates the server encountered an unexpected condition

--- a/transport_test.go
+++ b/transport_test.go
@@ -14,7 +14,19 @@ func TestMessageTypeConstants(t *testing.T) {
 }
 
 func TestStatusCodeConstants(t *testing.T) {
+	// Standard codes — valid to send in a close frame.
 	assert.Equal(t, wspulse.StatusCode(1000), wspulse.StatusNormalClosure)
 	assert.Equal(t, wspulse.StatusCode(1001), wspulse.StatusGoingAway)
+	assert.Equal(t, wspulse.StatusCode(1002), wspulse.StatusProtocolError)
+	assert.Equal(t, wspulse.StatusCode(1003), wspulse.StatusUnsupportedData)
+	assert.Equal(t, wspulse.StatusCode(1007), wspulse.StatusInvalidFramePayloadData)
+	assert.Equal(t, wspulse.StatusCode(1008), wspulse.StatusPolicyViolation)
+	assert.Equal(t, wspulse.StatusCode(1009), wspulse.StatusMessageTooBig)
+	assert.Equal(t, wspulse.StatusCode(1010), wspulse.StatusMandatoryExtension)
+	assert.Equal(t, wspulse.StatusCode(1011), wspulse.StatusInternalError)
+
+	// Local-only codes — MUST NOT be sent in a close frame (RFC 6455 §7.4.1).
+	assert.Equal(t, wspulse.StatusCode(1005), wspulse.StatusNoStatusReceived)
 	assert.Equal(t, wspulse.StatusCode(1006), wspulse.StatusAbnormalClosure)
+	assert.Equal(t, wspulse.StatusCode(1015), wspulse.StatusTLSHandshake)
 }


### PR DESCRIPTION
## Summary

Expands the `StatusCode` const block to cover all RFC 6455 §7.4.1 close codes (except 1004, which RFC explicitly marks as "MUST NOT be used"). Local-only codes that must not be sent in close frames are clearly documented.

## Related issues

Relates to wspulse/.github#32

## Changes

- Added `StatusProtocolError` (1002), `StatusUnsupportedData` (1003), `StatusNoStatusReceived` (1005), `StatusInvalidFramePayloadData` (1007), `StatusPolicyViolation` (1008), `StatusMessageTooBig` (1009), `StatusMandatoryExtension` (1010), `StatusInternalError` (1011), `StatusTLSHandshake` (1015)
- Grouped const block into two sections with doc comment: standard codes valid on the wire vs. local-only codes (1005, 1006, 1015) that RFC 6455 §7.4.1 forbids sending in a close frame
- Extended `TestStatusCodeConstants` to assert all new constants
- Added `[Unreleased]` CHANGELOG entry

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional (list only those that apply)

- [x] New public API: includes GoDoc comments