### PR TITLE
release: v0.6.1

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,47 @@
+name: Benchmark
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [develop]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.github/instructions/**'
+  pull_request:
+    branches: [main, develop]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.github/instructions/**'
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Download modules
+        run: go mod download
+
+      - name: Run benchmarks
+        run: make bench-ci
+
+      - name: Upload bench output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-${{ github.sha }}
+          path: bench.txt
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -306,4 +306,4 @@ yarn-error.log*
 Thumbs.db
 
 # Misc
-*.pem
+*.pembench.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 ### Added
 
 - Benchmark harness with `make bench-ci`, `make bench-sync`, and a CI
-  workflow that uploads `bench.txt` as an artefact on every PR. See
-  `doc/bench.md` for the baseline numbers. (#40)
+  workflow that uploads `bench.txt` as an artefact on every code PR
+  (the workflow ignores Markdown / LICENSE / `.github/instructions/**`
+  changes). See `doc/bench.md` for the baseline numbers. (#40)
 
 ## [0.6.0] - 2026-04-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+
+- Benchmark harness with `make bench-ci`, `make bench-sync`, and a CI
+  workflow that uploads `bench.txt` as an artefact on every PR. See
+  `doc/bench.md` for the baseline numbers. (#40)
+
 ## [0.6.0] - 2026-04-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-05-18
+
 ### Added
 
 - Benchmark harness with `make bench-ci`, `make bench-sync`, and a CI
@@ -79,7 +81,8 @@
 - `TextMessage` (1) and `BinaryMessage` (2) untyped int constants for WebSocket frame types
 - `ErrConnectionClosed` and `ErrSendBufferFull` sentinel errors
 
-[Unreleased]: https://github.com/wspulse/core/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/wspulse/core/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/wspulse/core/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/wspulse/core/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/wspulse/core/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/wspulse/core/compare/v0.3.1...v0.4.0

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-# bash gives us `set -o pipefail` and `trap` for the bench targets below;
-# all existing recipes are POSIX-compatible so this is safe.
-SHELL := /bin/bash
+# bash (looked up via PATH, not hardcoded to /bin/bash) gives us
+# `set -o pipefail` and `trap` for the bench targets below; all existing
+# recipes are POSIX-compatible so this is safe.
+SHELL := bash
 
 .PHONY: help test test-cover bench bench-ci bench-sync lint fmt check tidy deps clean
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,8 @@
-# bash (looked up via PATH, not hardcoded to /bin/bash) gives us
-# `set -o pipefail` and `trap` for the bench targets below; all existing
-# recipes are POSIX-compatible so this is safe.
-SHELL := bash
-
 .PHONY: help test test-cover bench bench-ci bench-sync lint fmt check tidy deps clean
+
+# bench-ci and bench-sync use bash for `set -o pipefail` and `trap`; all
+# other recipes stay POSIX-compatible so they run in any /bin/sh.
+bench-ci bench-sync: SHELL := bash
 
 # Default target
 help: ## Show available commands

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ bench-ci: ## Run the CI benchmark suite and write results to BENCH_OUT or bench.
 bench-sync: ## Refresh doc/bench.md from a fresh local benchmark run
 	@echo "── running benchmarks ──"
 	@set -e; \
-		tmpfile="$$(mktemp)"; \
+		tmpfile="$$(mktemp -t wspulse-benchsync.XXXXXX)"; \
 		trap 'rm -f "$$tmpfile"' EXIT; \
 		$(MAKE) --no-print-directory bench-ci BENCH_OUT="$$tmpfile"; \
 		echo "── refreshing doc/bench.md ──"; \

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,14 @@ bench-ci: ## Run the CI benchmark suite and write results to BENCH_OUT or bench.
 		go test -bench=. -benchmem -benchtime=3s -count=1 -run=^$$ ./... | tee "$$outfile"
 
 bench-sync: ## Refresh doc/bench.md from a fresh local benchmark run
+	@echo "── running benchmarks ──"
 	@set -e; \
 		tmpfile="$$(mktemp)"; \
 		trap 'rm -f "$$tmpfile"' EXIT; \
-		$(MAKE) --no-print-directory bench-ci BENCH_OUT="$$tmpfile" > /dev/null; \
-		go run ./cmd/benchsync -input "$$tmpfile"
+		$(MAKE) --no-print-directory bench-ci BENCH_OUT="$$tmpfile"; \
+		echo "── refreshing doc/bench.md ──"; \
+		go run ./cmd/benchsync -input "$$tmpfile"; \
+		echo "── done ──"
 
 lint: ## Run go vet and golangci-lint
 	@go vet ./...

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+# bash gives us `set -o pipefail` and `trap` for the bench targets below;
+# all existing recipes are POSIX-compatible so this is safe.
+SHELL := /bin/bash
+
 .PHONY: help test test-cover bench bench-ci bench-sync lint fmt check tidy deps clean
 
 # Default target
@@ -17,14 +21,16 @@ bench: ## Run benchmarks with memory allocation stats
 	@go test -bench=. -benchmem -run=^$$ ./...
 
 bench-ci: ## Run the CI benchmark suite and write results to BENCH_OUT or bench.txt
-	@outfile="$${BENCH_OUT:-bench.txt}"; \
+	@set -o pipefail; \
+		outfile="$${BENCH_OUT:-bench.txt}"; \
 		go test -bench=. -benchmem -benchtime=3s -count=1 -run=^$$ ./... | tee "$$outfile"
 
 bench-sync: ## Refresh doc/bench.md from a fresh local benchmark run
-	@tmpfile="$$(mktemp)"; \
+	@set -e; \
+		tmpfile="$$(mktemp)"; \
+		trap 'rm -f "$$tmpfile"' EXIT; \
 		$(MAKE) --no-print-directory bench-ci BENCH_OUT="$$tmpfile" > /dev/null; \
-		go run ./cmd/benchsync -input "$$tmpfile"; \
-		rm -f "$$tmpfile"
+		go run ./cmd/benchsync -input "$$tmpfile"
 
 lint: ## Run go vet and golangci-lint
 	@go vet ./...

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test test-cover bench bench-ci lint fmt check tidy deps clean
+.PHONY: help test test-cover bench bench-ci bench-sync lint fmt check tidy deps clean
 
 # Default target
 help: ## Show available commands
@@ -19,6 +19,12 @@ bench: ## Run benchmarks with memory allocation stats
 bench-ci: ## Run the CI benchmark suite and write results to BENCH_OUT or bench.txt
 	@outfile="$${BENCH_OUT:-bench.txt}"; \
 		go test -bench=. -benchmem -benchtime=3s -count=1 -run=^$$ ./... | tee "$$outfile"
+
+bench-sync: ## Refresh doc/bench.md from a fresh local benchmark run
+	@tmpfile="$$(mktemp)"; \
+		$(MAKE) --no-print-directory bench-ci BENCH_OUT="$$tmpfile" > /dev/null; \
+		go run ./cmd/benchsync -input "$$tmpfile"; \
+		rm -f "$$tmpfile"
 
 lint: ## Run go vet and golangci-lint
 	@go vet ./...

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test test-cover bench lint fmt check tidy deps clean
+.PHONY: help test test-cover bench bench-ci lint fmt check tidy deps clean
 
 # Default target
 help: ## Show available commands
@@ -15,6 +15,10 @@ test-cover: ## Run tests with coverage report
 
 bench: ## Run benchmarks with memory allocation stats
 	@go test -bench=. -benchmem -run=^$$ ./...
+
+bench-ci: ## Run the CI benchmark suite and write results to BENCH_OUT or bench.txt
+	@outfile="$${BENCH_OUT:-bench.txt}"; \
+		go test -bench=. -benchmem -benchtime=3s -count=1 -run=^$$ ./... | tee "$$outfile"
 
 lint: ## Run go vet and golangci-lint
 	@go vet ./...

--- a/cmd/benchsync/main.go
+++ b/cmd/benchsync/main.go
@@ -1,0 +1,287 @@
+// Command benchsync regenerates the benchmark tables in docs from a fresh
+// `go test -bench` output file. It parses the standard Go benchmark format,
+// emits one markdown row per known benchmark name, and replaces the table
+// inside a managed marker block in the target document.
+//
+// Run via `make bench-sync` from the repo root.
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var benchLinePattern = regexp.MustCompile(`^(Benchmark\S+?)(?:-\d+)?\s+\d+\s+(\S+)\s+ns/op\s+(\S+)\s+B/op\s+(\S+)\s+allocs/op$`)
+
+type benchEnv struct {
+	GOOS   string
+	GOARCH string
+	CPU    string
+}
+
+type benchReport struct {
+	Env     benchEnv
+	Results map[string]benchResult
+}
+
+type benchResult struct {
+	NSPerOp     string
+	BPerOp      string
+	AllocsPerOp string
+}
+
+type benchRow struct {
+	Name  string
+	Label string
+}
+
+type benchTarget struct {
+	Path       string
+	MarkerName string
+	Rows       []benchRow
+}
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string) error {
+	fs := flag.NewFlagSet("benchsync", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	root := fs.String("root", ".", "repository root")
+	inputPath := fs.String("input", "", "path to benchmark output")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *inputPath == "" {
+		return fmt.Errorf("input benchmark file is required")
+	}
+
+	input, err := os.ReadFile(*inputPath)
+	if err != nil {
+		return fmt.Errorf("read benchmark input: %w", err)
+	}
+
+	report, err := parseBenchResults(input)
+	if err != nil {
+		return err
+	}
+
+	for _, target := range defaultTargets(*root) {
+		markdown, err := os.ReadFile(target.Path)
+		if err != nil {
+			return fmt.Errorf("read markdown %s: %w", target.Path, err)
+		}
+
+		table, err := renderBenchTable(target.Rows, report)
+		if err != nil {
+			return err
+		}
+
+		updated, err := replaceManagedBlock(markdown, target.MarkerName, table)
+		if err != nil {
+			return fmt.Errorf("update %s: %w", target.Path, err)
+		}
+
+		if err := os.WriteFile(target.Path, updated, 0o644); err != nil {
+			return fmt.Errorf("write markdown %s: %w", target.Path, err)
+		}
+	}
+
+	return nil
+}
+
+// defaultTargets enumerates the benchmark tables maintained in doc/bench.md.
+// Each row maps a Go benchmark name (with sub-benchmark path, no -GOMAXPROCS
+// suffix) to its display label. Add new rows here when adding new benchmark
+// cases to keep doc/bench.md in sync.
+func defaultTargets(root string) []benchTarget {
+	sizes := []struct {
+		label string
+		tag   string
+	}{
+		{"64 B", "64B"},
+		{"1 KiB", "1KiB"},
+		{"16 KiB", "16KiB"},
+	}
+
+	var rows []benchRow
+	for _, ms := range sizes {
+		rows = append(rows, benchRow{
+			Name:  fmt.Sprintf("BenchmarkJSONCodecEncode/messageSize=%s", ms.tag),
+			Label: fmt.Sprintf("JSONCodec Encode (%s)", ms.label),
+		})
+	}
+	for _, ms := range sizes {
+		rows = append(rows, benchRow{
+			Name:  fmt.Sprintf("BenchmarkJSONCodecDecode/messageSize=%s", ms.tag),
+			Label: fmt.Sprintf("JSONCodec Decode (%s)", ms.label),
+		})
+	}
+	rows = append(rows, benchRow{
+		Name:  "BenchmarkMessageAlloc",
+		Label: "Message struct alloc",
+	})
+	for _, hc := range []int{1, 10, 100} {
+		for _, mw := range []int{0, 3} {
+			rows = append(rows, benchRow{
+				Name:  fmt.Sprintf("BenchmarkRouterDispatch/handlers=%d/middleware=%d", hc, mw),
+				Label: fmt.Sprintf("Router Dispatch (%d handlers, %d mw)", hc, mw),
+			})
+		}
+	}
+
+	return []benchTarget{
+		{
+			Path:       filepath.Join(root, "doc", "bench.md"),
+			MarkerName: "benchsync:core",
+			Rows:       rows,
+		},
+	}
+}
+
+func parseBenchResults(input []byte) (benchReport, error) {
+	report := benchReport{
+		Results: make(map[string]benchResult),
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(input))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		switch {
+		case strings.HasPrefix(line, "goos: "):
+			report.Env.GOOS = strings.TrimSpace(strings.TrimPrefix(line, "goos: "))
+			continue
+		case strings.HasPrefix(line, "goarch: "):
+			report.Env.GOARCH = strings.TrimSpace(strings.TrimPrefix(line, "goarch: "))
+			continue
+		case strings.HasPrefix(line, "cpu: "):
+			report.Env.CPU = strings.TrimSpace(strings.TrimPrefix(line, "cpu: "))
+			continue
+		}
+
+		matches := benchLinePattern.FindStringSubmatch(line)
+		if len(matches) == 0 {
+			continue
+		}
+
+		report.Results[matches[1]] = benchResult{
+			NSPerOp:     matches[2],
+			BPerOp:      matches[3],
+			AllocsPerOp: matches[4],
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return benchReport{}, fmt.Errorf("scan benchmark output: %w", err)
+	}
+	return report, nil
+}
+
+func renderBenchTable(rows []benchRow, report benchReport) (string, error) {
+	var out strings.Builder
+
+	if measurementLine := formatMeasurementLine(report.Env); measurementLine != "" {
+		out.WriteString(measurementLine)
+		out.WriteString("\n\n")
+	}
+
+	out.WriteString("| Operation | ns/op | B/op | allocs/op |\n")
+	out.WriteString("|---|---:|---:|---:|\n")
+
+	for _, row := range rows {
+		result, ok := report.Results[row.Name]
+		if !ok {
+			return "", fmt.Errorf("missing benchmark result for %s", row.Name)
+		}
+
+		if _, err := fmt.Fprintf(&out, "| `%s` | %s | %s | %s |\n",
+			row.Label,
+			formatMetric(result.NSPerOp),
+			formatMetric(result.BPerOp),
+			formatMetric(result.AllocsPerOp),
+		); err != nil {
+			return "", fmt.Errorf("render benchmark row %s: %w", row.Name, err)
+		}
+	}
+
+	return strings.TrimRight(out.String(), "\n"), nil
+}
+
+func formatMeasurementLine(env benchEnv) string {
+	platform := strings.Trim(strings.TrimSpace(env.GOOS)+"/"+strings.TrimSpace(env.GOARCH), "/")
+	switch {
+	case platform != "" && env.CPU != "":
+		return fmt.Sprintf("Measured on `%s` (`%s`).", platform, env.CPU)
+	case platform != "":
+		return fmt.Sprintf("Measured on `%s`.", platform)
+	case env.CPU != "":
+		return fmt.Sprintf("Measured on `%s`.", env.CPU)
+	default:
+		return ""
+	}
+}
+
+func replaceManagedBlock(markdown []byte, marker, content string) ([]byte, error) {
+	startMarker := "<!-- " + marker + ":start -->"
+	endMarker := "<!-- " + marker + ":end -->"
+
+	start := bytes.Index(markdown, []byte(startMarker))
+	if start == -1 {
+		return nil, fmt.Errorf("start marker not found: %s", marker)
+	}
+
+	end := bytes.Index(markdown[start:], []byte(endMarker))
+	if end == -1 {
+		return nil, fmt.Errorf("end marker not found: %s", marker)
+	}
+	end += start
+
+	var out bytes.Buffer
+	out.Write(markdown[:start+len(startMarker)])
+	out.WriteString("\n")
+	out.WriteString(content)
+	out.WriteString("\n")
+	out.Write(markdown[end:])
+	return out.Bytes(), nil
+}
+
+func formatMetric(value string) string {
+	if strings.Contains(value, ".") {
+		return strings.TrimRight(strings.TrimRight(value, "0"), ".")
+	}
+
+	n, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return value
+	}
+
+	sign := ""
+	if n < 0 {
+		sign = "-"
+		n = -n
+	}
+
+	raw := strconv.FormatInt(n, 10)
+	if len(raw) <= 3 {
+		return sign + raw
+	}
+
+	var parts []string
+	for len(raw) > 3 {
+		parts = append([]string{raw[len(raw)-3:]}, parts...)
+		raw = raw[:len(raw)-3]
+	}
+	parts = append([]string{raw}, parts...)
+	return sign + strings.Join(parts, ",")
+}

--- a/cmd/benchsync/main.go
+++ b/cmd/benchsync/main.go
@@ -134,10 +134,14 @@ func defaultTargets(root string) []benchTarget {
 		Label: "Message struct alloc",
 	})
 	for _, hc := range []int{1, 10, 100} {
+		handlerWord := "handlers"
+		if hc == 1 {
+			handlerWord = "handler"
+		}
 		for _, mw := range []int{0, 3} {
 			rows = append(rows, benchRow{
 				Name:  fmt.Sprintf("BenchmarkRouterDispatch/handlers=%d/middleware=%d", hc, mw),
-				Label: fmt.Sprintf("Router Dispatch (%d handlers, %d mw)", hc, mw),
+				Label: fmt.Sprintf("Router Dispatch (%d %s, %d mw)", hc, handlerWord, mw),
 			})
 		}
 	}

--- a/cmd/benchsync/main.go
+++ b/cmd/benchsync/main.go
@@ -6,8 +6,9 @@
 // The input must be produced with `-benchmem`: the parser only matches
 // lines that include the `B/op` and `allocs/op` columns. Without them
 // the parse returns no rows and `run` fails with "missing benchmark
-// result" for every expected target row. `make bench-ci` already passes
-// `-benchmem`, so use that target rather than invoking `go test` by hand.
+// result for ..." on the first expected target row it cannot find.
+// `make bench-ci` already passes `-benchmem`, so use that target rather
+// than invoking `go test` by hand.
 //
 // Run via `make bench-sync` from the repo root.
 package main

--- a/cmd/benchsync/main.go
+++ b/cmd/benchsync/main.go
@@ -1,7 +1,13 @@
 // Command benchsync regenerates the benchmark tables in docs from a fresh
-// `go test -bench` output file. It parses the standard Go benchmark format,
+// `go test -bench` output file. It parses the bench output line-by-line,
 // emits one markdown row per known benchmark name, and replaces the table
 // inside a managed marker block in the target document.
+//
+// The input must be produced with `-benchmem`: the parser only matches
+// lines that include the `B/op` and `allocs/op` columns. Without them
+// the parse returns no rows and `run` fails with "missing benchmark
+// result" for every expected target row. `make bench-ci` already passes
+// `-benchmem`, so use that target rather than invoking `go test` by hand.
 //
 // Run via `make bench-sync` from the repo root.
 package main

--- a/cmd/benchsync/main.go
+++ b/cmd/benchsync/main.go
@@ -133,15 +133,15 @@ func defaultTargets(root string) []benchTarget {
 		Name:  "BenchmarkMessageAlloc",
 		Label: "Message struct alloc",
 	})
-	for _, hc := range []int{1, 10, 100} {
-		handlerWord := "handlers"
-		if hc == 1 {
-			handlerWord = "handler"
+	for _, rc := range []int{1, 10, 100} {
+		routeWord := "routes"
+		if rc == 1 {
+			routeWord = "route"
 		}
 		for _, mw := range []int{0, 3} {
 			rows = append(rows, benchRow{
-				Name:  fmt.Sprintf("BenchmarkRouterDispatch/handlers=%d/middleware=%d", hc, mw),
-				Label: fmt.Sprintf("Router Dispatch (%d %s, %d mw)", hc, handlerWord, mw),
+				Name:  fmt.Sprintf("BenchmarkRouterDispatch/routes=%d/middleware=%d", rc, mw),
+				Label: fmt.Sprintf("Router Dispatch (%d %s, %d mw)", rc, routeWord, mw),
 			})
 		}
 	}

--- a/cmd/benchsync/main_test.go
+++ b/cmd/benchsync/main_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseBenchResults_CoreNames(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`
+goos: darwin
+goarch: arm64
+cpu: Apple M1 Max
+BenchmarkJSONCodecEncode/messageSize=64B-10            5000000      720 ns/op    256 B/op    3 allocs/op
+BenchmarkJSONCodecDecode/messageSize=16KiB-10            50000     6500 ns/op   4500 B/op    7 allocs/op
+BenchmarkMessageAlloc-10                            500000000     2.5 ns/op       0 B/op    0 allocs/op
+BenchmarkRouterDispatch/handlers=100/middleware=3-10   100000     1530 ns/op    400 B/op    9 allocs/op
+PASS
+`)
+
+	got, err := parseBenchResults(input)
+	require.NoError(t, err)
+
+	assert.Equal(t, "720", got.Results["BenchmarkJSONCodecEncode/messageSize=64B"].NSPerOp)
+	assert.Equal(t, "6500", got.Results["BenchmarkJSONCodecDecode/messageSize=16KiB"].NSPerOp)
+	assert.Equal(t, "2.5", got.Results["BenchmarkMessageAlloc"].NSPerOp)
+	assert.Equal(t, "1530", got.Results["BenchmarkRouterDispatch/handlers=100/middleware=3"].NSPerOp)
+}
+
+func TestRun(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "doc"), 0o755))
+
+	benchFile := filepath.Join(root, "bench.txt")
+	require.NoError(t, os.WriteFile(benchFile, []byte(`
+goos: darwin
+goarch: arm64
+cpu: Apple M1 Max
+BenchmarkJSONCodecEncode/messageSize=64B-10            5000000     720 ns/op    256 B/op    3 allocs/op
+BenchmarkJSONCodecEncode/messageSize=1KiB-10           1000000    1500 ns/op   1300 B/op    3 allocs/op
+BenchmarkJSONCodecEncode/messageSize=16KiB-10           100000   12000 ns/op  17000 B/op    3 allocs/op
+BenchmarkJSONCodecDecode/messageSize=64B-10            3000000     820 ns/op    320 B/op    5 allocs/op
+BenchmarkJSONCodecDecode/messageSize=1KiB-10            800000    1700 ns/op   1400 B/op    5 allocs/op
+BenchmarkJSONCodecDecode/messageSize=16KiB-10            50000    6500 ns/op   4500 B/op    7 allocs/op
+BenchmarkMessageAlloc-10                            500000000     2.5 ns/op       0 B/op    0 allocs/op
+BenchmarkRouterDispatch/handlers=1/middleware=0-10    2000000     560 ns/op    256 B/op    2 allocs/op
+BenchmarkRouterDispatch/handlers=1/middleware=3-10    1500000     720 ns/op    288 B/op    5 allocs/op
+BenchmarkRouterDispatch/handlers=10/middleware=0-10   1500000     650 ns/op    280 B/op    3 allocs/op
+BenchmarkRouterDispatch/handlers=10/middleware=3-10   1000000     820 ns/op    320 B/op    6 allocs/op
+BenchmarkRouterDispatch/handlers=100/middleware=0-10   500000    1230 ns/op    320 B/op    6 allocs/op
+BenchmarkRouterDispatch/handlers=100/middleware=3-10   100000    1530 ns/op    400 B/op    9 allocs/op
+`), 0o644))
+
+	docPath := filepath.Join(root, "doc", "bench.md")
+	require.NoError(t, os.WriteFile(docPath, []byte(strings.TrimSpace(`
+# Benchmarks
+
+<!-- benchsync:core:start -->
+stale
+<!-- benchsync:core:end -->
+`)+"\n"), 0o644))
+
+	require.NoError(t, run([]string{"-root", root, "-input", benchFile}))
+
+	got, err := os.ReadFile(docPath)
+	require.NoError(t, err)
+	doc := string(got)
+
+	assert.Contains(t, doc, "Measured on `darwin/arm64` (`Apple M1 Max`).")
+	assert.Contains(t, doc, "| `JSONCodec Encode (64 B)` | 720 | 256 | 3 |")
+	assert.Contains(t, doc, "| `JSONCodec Decode (16 KiB)` | 6,500 | 4,500 | 7 |")
+	assert.Contains(t, doc, "| `Message struct alloc` | 2.5 | 0 | 0 |")
+	assert.Contains(t, doc, "| `Router Dispatch (100 handlers, 3 mw)` | 1,530 | 400 | 9 |")
+}
+
+func TestRun_MissingResult(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "doc"), 0o755))
+
+	benchFile := filepath.Join(root, "bench.txt")
+	require.NoError(t, os.WriteFile(benchFile, []byte(`
+BenchmarkMessageAlloc-10  100 100 ns/op 0 B/op 0 allocs/op
+`), 0o644))
+
+	docPath := filepath.Join(root, "doc", "bench.md")
+	require.NoError(t, os.WriteFile(docPath, []byte("<!-- benchsync:core:start -->\n<!-- benchsync:core:end -->\n"), 0o644))
+
+	err := run([]string{"-root", root, "-input", benchFile})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing benchmark result")
+}
+
+func TestFormatMetric(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "107", formatMetric("107.0"))
+	assert.Equal(t, "5.59", formatMetric("5.590"))
+	assert.Equal(t, "1,626", formatMetric("1626"))
+	assert.Equal(t, "3.007", formatMetric("3.007"))
+}

--- a/cmd/benchsync/main_test.go
+++ b/cmd/benchsync/main_test.go
@@ -20,7 +20,7 @@ cpu: Apple M1 Max
 BenchmarkJSONCodecEncode/messageSize=64B-10            5000000      720 ns/op    256 B/op    3 allocs/op
 BenchmarkJSONCodecDecode/messageSize=16KiB-10            50000     6500 ns/op   4500 B/op    7 allocs/op
 BenchmarkMessageAlloc-10                            500000000     2.5 ns/op       0 B/op    0 allocs/op
-BenchmarkRouterDispatch/handlers=100/middleware=3-10   100000     1530 ns/op    400 B/op    9 allocs/op
+BenchmarkRouterDispatch/routes=100/middleware=3-10     100000     1530 ns/op    400 B/op    9 allocs/op
 PASS
 `)
 
@@ -30,7 +30,7 @@ PASS
 	assert.Equal(t, "720", got.Results["BenchmarkJSONCodecEncode/messageSize=64B"].NSPerOp)
 	assert.Equal(t, "6500", got.Results["BenchmarkJSONCodecDecode/messageSize=16KiB"].NSPerOp)
 	assert.Equal(t, "2.5", got.Results["BenchmarkMessageAlloc"].NSPerOp)
-	assert.Equal(t, "1530", got.Results["BenchmarkRouterDispatch/handlers=100/middleware=3"].NSPerOp)
+	assert.Equal(t, "1530", got.Results["BenchmarkRouterDispatch/routes=100/middleware=3"].NSPerOp)
 }
 
 func TestRun(t *testing.T) {
@@ -51,12 +51,12 @@ BenchmarkJSONCodecDecode/messageSize=64B-10            3000000     820 ns/op    
 BenchmarkJSONCodecDecode/messageSize=1KiB-10            800000    1700 ns/op   1400 B/op    5 allocs/op
 BenchmarkJSONCodecDecode/messageSize=16KiB-10            50000    6500 ns/op   4500 B/op    7 allocs/op
 BenchmarkMessageAlloc-10                            500000000     2.5 ns/op       0 B/op    0 allocs/op
-BenchmarkRouterDispatch/handlers=1/middleware=0-10    2000000     560 ns/op    256 B/op    2 allocs/op
-BenchmarkRouterDispatch/handlers=1/middleware=3-10    1500000     720 ns/op    288 B/op    5 allocs/op
-BenchmarkRouterDispatch/handlers=10/middleware=0-10   1500000     650 ns/op    280 B/op    3 allocs/op
-BenchmarkRouterDispatch/handlers=10/middleware=3-10   1000000     820 ns/op    320 B/op    6 allocs/op
-BenchmarkRouterDispatch/handlers=100/middleware=0-10   500000    1230 ns/op    320 B/op    6 allocs/op
-BenchmarkRouterDispatch/handlers=100/middleware=3-10   100000    1530 ns/op    400 B/op    9 allocs/op
+BenchmarkRouterDispatch/routes=1/middleware=0-10    2000000     560 ns/op    256 B/op    2 allocs/op
+BenchmarkRouterDispatch/routes=1/middleware=3-10    1500000     720 ns/op    288 B/op    5 allocs/op
+BenchmarkRouterDispatch/routes=10/middleware=0-10   1500000     650 ns/op    280 B/op    3 allocs/op
+BenchmarkRouterDispatch/routes=10/middleware=3-10   1000000     820 ns/op    320 B/op    6 allocs/op
+BenchmarkRouterDispatch/routes=100/middleware=0-10   500000    1230 ns/op    320 B/op    6 allocs/op
+BenchmarkRouterDispatch/routes=100/middleware=3-10   100000    1530 ns/op    400 B/op    9 allocs/op
 `), 0o644))
 
 	docPath := filepath.Join(root, "doc", "bench.md")
@@ -78,8 +78,8 @@ stale
 	assert.Contains(t, doc, "| `JSONCodec Encode (64 B)` | 720 | 256 | 3 |")
 	assert.Contains(t, doc, "| `JSONCodec Decode (16 KiB)` | 6,500 | 4,500 | 7 |")
 	assert.Contains(t, doc, "| `Message struct alloc` | 2.5 | 0 | 0 |")
-	assert.Contains(t, doc, "| `Router Dispatch (1 handler, 0 mw)` | 560 | 256 | 2 |")
-	assert.Contains(t, doc, "| `Router Dispatch (100 handlers, 3 mw)` | 1,530 | 400 | 9 |")
+	assert.Contains(t, doc, "| `Router Dispatch (1 route, 0 mw)` | 560 | 256 | 2 |")
+	assert.Contains(t, doc, "| `Router Dispatch (100 routes, 3 mw)` | 1,530 | 400 | 9 |")
 }
 
 func TestRun_MissingResult(t *testing.T) {

--- a/cmd/benchsync/main_test.go
+++ b/cmd/benchsync/main_test.go
@@ -78,6 +78,7 @@ stale
 	assert.Contains(t, doc, "| `JSONCodec Encode (64 B)` | 720 | 256 | 3 |")
 	assert.Contains(t, doc, "| `JSONCodec Decode (16 KiB)` | 6,500 | 4,500 | 7 |")
 	assert.Contains(t, doc, "| `Message struct alloc` | 2.5 | 0 | 0 |")
+	assert.Contains(t, doc, "| `Router Dispatch (1 handler, 0 mw)` | 560 | 256 | 2 |")
 	assert.Contains(t, doc, "| `Router Dispatch (100 handlers, 3 mw)` | 1,530 | 400 | 9 |")
 }
 

--- a/codec_bench_test.go
+++ b/codec_bench_test.go
@@ -33,8 +33,7 @@ func BenchmarkJSONCodecEncode(b *testing.B) {
 		b.Run(fmt.Sprintf("messageSize=%s", ms.label), func(b *testing.B) {
 			msg := wspulse.Message{Event: "bench", Payload: jsonPayload(ms.size)}
 			b.ReportAllocs()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				_, err := wspulse.JSONCodec.Encode(msg)
 				if err != nil {
 					b.Fatalf("Encode: %v", err)
@@ -53,8 +52,7 @@ func BenchmarkJSONCodecDecode(b *testing.B) {
 				b.Fatalf("setup Encode: %v", err)
 			}
 			b.ReportAllocs()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				if _, err := wspulse.JSONCodec.Decode(encoded); err != nil {
 					b.Fatalf("Decode: %v", err)
 				}

--- a/codec_bench_test.go
+++ b/codec_bench_test.go
@@ -1,0 +1,64 @@
+package wspulse_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	wspulse "github.com/wspulse/core"
+)
+
+// jsonPayload returns a valid JSON string payload of total byte length size.
+// size includes the surrounding quotes; minimum is 2 (an empty JSON string).
+func jsonPayload(size int) []byte {
+	if size < 2 {
+		size = 2
+	}
+	return []byte(`"` + strings.Repeat("x", size-2) + `"`)
+}
+
+// messageSizes is the standard payload size matrix for codec benchmarks.
+// Values match the workspace bench-harness plan.
+var messageSizes = []struct {
+	label string
+	size  int
+}{
+	{"64B", 64},
+	{"1KiB", 1024},
+	{"16KiB", 16 * 1024},
+}
+
+func BenchmarkJSONCodecEncode(b *testing.B) {
+	for _, ms := range messageSizes {
+		b.Run(fmt.Sprintf("messageSize=%s", ms.label), func(b *testing.B) {
+			msg := wspulse.Message{Event: "bench", Payload: jsonPayload(ms.size)}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := wspulse.JSONCodec.Encode(msg)
+				if err != nil {
+					b.Fatalf("Encode: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkJSONCodecDecode(b *testing.B) {
+	for _, ms := range messageSizes {
+		b.Run(fmt.Sprintf("messageSize=%s", ms.label), func(b *testing.B) {
+			msg := wspulse.Message{Event: "bench", Payload: jsonPayload(ms.size)}
+			encoded, err := wspulse.JSONCodec.Encode(msg)
+			if err != nil {
+				b.Fatalf("setup Encode: %v", err)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := wspulse.JSONCodec.Decode(encoded); err != nil {
+					b.Fatalf("Decode: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/doc/bench.md
+++ b/doc/bench.md
@@ -32,17 +32,17 @@ Measured on `darwin/arm64` (`Apple M1 Max`).
 
 | Operation | ns/op | B/op | allocs/op |
 |---|---:|---:|---:|
-| `JSONCodec Encode (64 B)` | 389.4 | 144 | 2 |
-| `JSONCodec Encode (1 KiB)` | 3,866 | 1,200 | 2 |
-| `JSONCodec Encode (16 KiB)` | 58,321 | 18,495 | 2 |
-| `JSONCodec Decode (64 B)` | 633.1 | 336 | 7 |
-| `JSONCodec Decode (1 KiB)` | 3,475 | 1,296 | 7 |
-| `JSONCodec Decode (16 KiB)` | 48,446 | 16,656 | 7 |
-| `Message struct alloc` | 1.239 | 0 | 0 |
-| `Router Dispatch (1 route, 0 mw)` | 18.84 | 0 | 0 |
-| `Router Dispatch (1 route, 3 mw)` | 23.14 | 0 | 0 |
-| `Router Dispatch (10 routes, 0 mw)` | 28.92 | 0 | 0 |
-| `Router Dispatch (10 routes, 3 mw)` | 32.47 | 0 | 0 |
-| `Router Dispatch (100 routes, 0 mw)` | 30.11 | 0 | 0 |
-| `Router Dispatch (100 routes, 3 mw)` | 34.08 | 0 | 0 |
+| `JSONCodec Encode (64 B)` | 392.5 | 144 | 2 |
+| `JSONCodec Encode (1 KiB)` | 3,877 | 1,200 | 2 |
+| `JSONCodec Encode (16 KiB)` | 59,985 | 18,496 | 2 |
+| `JSONCodec Decode (64 B)` | 640.9 | 336 | 7 |
+| `JSONCodec Decode (1 KiB)` | 3,520 | 1,296 | 7 |
+| `JSONCodec Decode (16 KiB)` | 48,873 | 16,656 | 7 |
+| `Message struct alloc` | 1.245 | 0 | 0 |
+| `Router Dispatch (1 route, 0 mw)` | 19.69 | 0 | 0 |
+| `Router Dispatch (1 route, 3 mw)` | 29.86 | 0 | 0 |
+| `Router Dispatch (10 routes, 0 mw)` | 29.3 | 0 | 0 |
+| `Router Dispatch (10 routes, 3 mw)` | 36.52 | 0 | 0 |
+| `Router Dispatch (100 routes, 0 mw)` | 30.44 | 0 | 0 |
+| `Router Dispatch (100 routes, 3 mw)` | 39.86 | 0 | 0 |
 <!-- benchsync:core:end -->

--- a/doc/bench.md
+++ b/doc/bench.md
@@ -18,9 +18,11 @@ The matrix covers:
 - `JSONCodec Encode` / `Decode` — wire-format encoding cost across
   `messageSize ∈ {64 B, 1 KiB, 16 KiB}`. Shared by every wspulse SDK that
   speaks the JSON protocol; allocation count especially matters.
-- `Message struct alloc` — bare struct construction + payload assignment.
-  Watchdog bench: should report 0 allocs (Go escape analysis keeps the value
-  on the stack); a regression to non-zero is a red flag.
+- `Message struct alloc` — bare struct construction + payload assignment
+  written into a package-level sink (so the compiler cannot elide the loop).
+  Watchdog bench: should report 0 allocs (the sink is a fixed slot, not a
+  per-iteration allocation, and the payload is just a slice-header copy);
+  a regression to non-zero is a red flag.
 - `Router Dispatch` — event routing cost across `routes ∈ {1, 10, 100}`
   (number of registered events, each with one terminal handler) and
   `middleware ∈ {0, 3}` (global middleware depth prepended to every chain).

--- a/doc/bench.md
+++ b/doc/bench.md
@@ -20,9 +20,9 @@ The matrix covers:
 - `Message struct alloc` — bare struct construction + payload assignment.
   Watchdog bench: should report 0 allocs (Go escape analysis keeps the value
   on the stack); a regression to non-zero is a red flag.
-- `Router Dispatch` — event routing cost across `handlers ∈ {1, 10, 100}`
-  (router map size, one terminal handler per event) and `middleware ∈ {0, 3}`
-  (global middleware depth prepended to every chain).
+- `Router Dispatch` — event routing cost across `routes ∈ {1, 10, 100}`
+  (number of registered events, each with one terminal handler) and
+  `middleware ∈ {0, 3}` (global middleware depth prepended to every chain).
 
 <!-- benchsync:core:start -->
 Measured on `darwin/arm64` (`Apple M1 Max`).

--- a/doc/bench.md
+++ b/doc/bench.md
@@ -32,17 +32,17 @@ Measured on `darwin/arm64` (`Apple M1 Max`).
 
 | Operation | ns/op | B/op | allocs/op |
 |---|---:|---:|---:|
-| `JSONCodec Encode (64 B)` | 392.5 | 144 | 2 |
-| `JSONCodec Encode (1 KiB)` | 3,877 | 1,200 | 2 |
-| `JSONCodec Encode (16 KiB)` | 59,985 | 18,496 | 2 |
-| `JSONCodec Decode (64 B)` | 640.9 | 336 | 7 |
-| `JSONCodec Decode (1 KiB)` | 3,520 | 1,296 | 7 |
-| `JSONCodec Decode (16 KiB)` | 48,873 | 16,656 | 7 |
-| `Message struct alloc` | 1.245 | 0 | 0 |
-| `Router Dispatch (1 route, 0 mw)` | 19.69 | 0 | 0 |
-| `Router Dispatch (1 route, 3 mw)` | 29.86 | 0 | 0 |
-| `Router Dispatch (10 routes, 0 mw)` | 29.3 | 0 | 0 |
-| `Router Dispatch (10 routes, 3 mw)` | 36.52 | 0 | 0 |
-| `Router Dispatch (100 routes, 0 mw)` | 30.44 | 0 | 0 |
-| `Router Dispatch (100 routes, 3 mw)` | 39.86 | 0 | 0 |
+| `JSONCodec Encode (64 B)` | 395 | 144 | 2 |
+| `JSONCodec Encode (1 KiB)` | 3,887 | 1,200 | 2 |
+| `JSONCodec Encode (16 KiB)` | 58,378 | 18,495 | 2 |
+| `JSONCodec Decode (64 B)` | 635.9 | 336 | 7 |
+| `JSONCodec Decode (1 KiB)` | 3,538 | 1,296 | 7 |
+| `JSONCodec Decode (16 KiB)` | 48,728 | 16,656 | 7 |
+| `Message struct alloc` | 2.268 | 0 | 0 |
+| `Router Dispatch (1 route, 0 mw)` | 19.02 | 0 | 0 |
+| `Router Dispatch (1 route, 3 mw)` | 34.12 | 0 | 0 |
+| `Router Dispatch (10 routes, 0 mw)` | 28.73 | 0 | 0 |
+| `Router Dispatch (10 routes, 3 mw)` | 38.48 | 0 | 0 |
+| `Router Dispatch (100 routes, 0 mw)` | 30.01 | 0 | 0 |
+| `Router Dispatch (100 routes, 3 mw)` | 39.75 | 0 | 0 |
 <!-- benchsync:core:end -->

--- a/doc/bench.md
+++ b/doc/bench.md
@@ -2,10 +2,11 @@
 
 The table below is a checked-in baseline for `wspulse/core`, last refreshed
 locally by a maintainer running `make bench-sync` on the hardware noted in
-the table. The CI workflow runs the same benchmarks on every PR and uploads
-the raw `bench.txt` as an artefact; download it from the run page if you
-need to compare specific numbers between branches. CI does not regenerate
-or commit this file.
+the table. The CI workflow runs the same benchmarks on every code PR (the
+workflow ignores Markdown / LICENSE / `.github/instructions/**` changes)
+and uploads the raw `bench.txt` as an artefact; download it from the run
+page if you need to compare specific numbers between branches. CI does not
+regenerate or commit this file.
 
 Variance between machines is expected — these baselines are a regression
 sanity check, not a portability claim. Single runs at `-benchtime=3s -count=1`

--- a/doc/bench.md
+++ b/doc/bench.md
@@ -29,17 +29,17 @@ Measured on `darwin/arm64` (`Apple M1 Max`).
 
 | Operation | ns/op | B/op | allocs/op |
 |---|---:|---:|---:|
-| `JSONCodec Encode (64 B)` | 390.3 | 144 | 2 |
-| `JSONCodec Encode (1 KiB)` | 3,833 | 1,200 | 2 |
-| `JSONCodec Encode (16 KiB)` | 58,294 | 18,496 | 2 |
-| `JSONCodec Decode (64 B)` | 633 | 336 | 7 |
-| `JSONCodec Decode (1 KiB)` | 3,477 | 1,296 | 7 |
-| `JSONCodec Decode (16 KiB)` | 48,459 | 16,656 | 7 |
-| `Message struct alloc` | 0.3164 | 0 | 0 |
-| `Router Dispatch (1 handlers, 0 mw)` | 18.88 | 0 | 0 |
-| `Router Dispatch (1 handlers, 3 mw)` | 23.27 | 0 | 0 |
-| `Router Dispatch (10 handlers, 0 mw)` | 28.86 | 0 | 0 |
-| `Router Dispatch (10 handlers, 3 mw)` | 32.39 | 0 | 0 |
-| `Router Dispatch (100 handlers, 0 mw)` | 33.05 | 0 | 0 |
-| `Router Dispatch (100 handlers, 3 mw)` | 33.73 | 0 | 0 |
+| `JSONCodec Encode (64 B)` | 386.4 | 144 | 2 |
+| `JSONCodec Encode (1 KiB)` | 3,827 | 1,200 | 2 |
+| `JSONCodec Encode (16 KiB)` | 58,631 | 18,496 | 2 |
+| `JSONCodec Decode (64 B)` | 636.9 | 336 | 7 |
+| `JSONCodec Decode (1 KiB)` | 3,468 | 1,296 | 7 |
+| `JSONCodec Decode (16 KiB)` | 48,221 | 16,656 | 7 |
+| `Message struct alloc` | 1.228 | 0 | 0 |
+| `Router Dispatch (1 handler, 0 mw)` | 18.81 | 0 | 0 |
+| `Router Dispatch (1 handler, 3 mw)` | 23.39 | 0 | 0 |
+| `Router Dispatch (10 handlers, 0 mw)` | 28.7 | 0 | 0 |
+| `Router Dispatch (10 handlers, 3 mw)` | 32.31 | 0 | 0 |
+| `Router Dispatch (100 handlers, 0 mw)` | 29.99 | 0 | 0 |
+| `Router Dispatch (100 handlers, 3 mw)` | 33.91 | 0 | 0 |
 <!-- benchsync:core:end -->

--- a/doc/bench.md
+++ b/doc/bench.md
@@ -17,7 +17,10 @@ The matrix covers:
 
 - `JSONCodec Encode` / `Decode` — wire-format encoding cost across
   `messageSize ∈ {64 B, 1 KiB, 16 KiB}`. Shared by every wspulse SDK that
-  speaks the JSON protocol; allocation count especially matters.
+  speaks the JSON protocol; allocation count especially matters. The axis
+  parameterises `Message.Payload` (the payload bytes); `Encode` adds a
+  fixed `event`/`payload` JSON envelope on top, so the encoded wire size
+  is roughly the labelled size + ~25 bytes of envelope.
 - `Message struct alloc` — bare struct construction + payload assignment
   written into a package-level sink (so the compiler cannot elide the loop).
   Watchdog bench: should report 0 allocs (the sink is a fixed slot, not a

--- a/doc/bench.md
+++ b/doc/bench.md
@@ -1,9 +1,11 @@
 # Benchmarks
 
-Numbers below are the latest CI-published baseline for `wspulse/core`.
-Regenerate locally with `make bench-sync`. The CI workflow uploads the raw
-`bench.txt` output as an artefact on every PR; download it from the run page
-if you need to compare specific numbers between branches.
+The table below is a checked-in baseline for `wspulse/core`, last refreshed
+locally by a maintainer running `make bench-sync` on the hardware noted in
+the table. The CI workflow runs the same benchmarks on every PR and uploads
+the raw `bench.txt` as an artefact; download it from the run page if you
+need to compare specific numbers between branches. CI does not regenerate
+or commit this file.
 
 Variance between machines is expected — these baselines are a regression
 sanity check, not a portability claim. Single runs at `-benchtime=3s -count=1`

--- a/doc/bench.md
+++ b/doc/bench.md
@@ -29,17 +29,17 @@ Measured on `darwin/arm64` (`Apple M1 Max`).
 
 | Operation | ns/op | B/op | allocs/op |
 |---|---:|---:|---:|
-| `JSONCodec Encode (64 B)` | 386.4 | 144 | 2 |
-| `JSONCodec Encode (1 KiB)` | 3,827 | 1,200 | 2 |
-| `JSONCodec Encode (16 KiB)` | 58,631 | 18,496 | 2 |
-| `JSONCodec Decode (64 B)` | 636.9 | 336 | 7 |
-| `JSONCodec Decode (1 KiB)` | 3,468 | 1,296 | 7 |
-| `JSONCodec Decode (16 KiB)` | 48,221 | 16,656 | 7 |
-| `Message struct alloc` | 1.228 | 0 | 0 |
-| `Router Dispatch (1 handler, 0 mw)` | 18.81 | 0 | 0 |
-| `Router Dispatch (1 handler, 3 mw)` | 23.39 | 0 | 0 |
-| `Router Dispatch (10 handlers, 0 mw)` | 28.7 | 0 | 0 |
-| `Router Dispatch (10 handlers, 3 mw)` | 32.31 | 0 | 0 |
-| `Router Dispatch (100 handlers, 0 mw)` | 29.99 | 0 | 0 |
-| `Router Dispatch (100 handlers, 3 mw)` | 33.91 | 0 | 0 |
+| `JSONCodec Encode (64 B)` | 389.4 | 144 | 2 |
+| `JSONCodec Encode (1 KiB)` | 3,866 | 1,200 | 2 |
+| `JSONCodec Encode (16 KiB)` | 58,321 | 18,495 | 2 |
+| `JSONCodec Decode (64 B)` | 633.1 | 336 | 7 |
+| `JSONCodec Decode (1 KiB)` | 3,475 | 1,296 | 7 |
+| `JSONCodec Decode (16 KiB)` | 48,446 | 16,656 | 7 |
+| `Message struct alloc` | 1.239 | 0 | 0 |
+| `Router Dispatch (1 route, 0 mw)` | 18.84 | 0 | 0 |
+| `Router Dispatch (1 route, 3 mw)` | 23.14 | 0 | 0 |
+| `Router Dispatch (10 routes, 0 mw)` | 28.92 | 0 | 0 |
+| `Router Dispatch (10 routes, 3 mw)` | 32.47 | 0 | 0 |
+| `Router Dispatch (100 routes, 0 mw)` | 30.11 | 0 | 0 |
+| `Router Dispatch (100 routes, 3 mw)` | 34.08 | 0 | 0 |
 <!-- benchsync:core:end -->

--- a/doc/bench.md
+++ b/doc/bench.md
@@ -1,0 +1,43 @@
+# Benchmarks
+
+Numbers below are the latest CI-published baseline for `wspulse/core`.
+Regenerate locally with `make bench-sync`. The CI workflow uploads the raw
+`bench.txt` output as an artefact on every PR; download it from the run page
+if you need to compare specific numbers between branches.
+
+Variance between machines is expected — these baselines are a regression
+sanity check, not a portability claim. Single runs at `-benchtime=3s -count=1`
+are noisy at the few-percent level; a one-off `bench-sync` is enough for
+order-of-magnitude regression detection but not micro-optimisation.
+
+The matrix covers:
+
+- `JSONCodec Encode` / `Decode` — wire-format encoding cost across
+  `messageSize ∈ {64 B, 1 KiB, 16 KiB}`. Shared by every wspulse SDK that
+  speaks the JSON protocol; allocation count especially matters.
+- `Message struct alloc` — bare struct construction + payload assignment.
+  Watchdog bench: should report 0 allocs (Go escape analysis keeps the value
+  on the stack); a regression to non-zero is a red flag.
+- `Router Dispatch` — event routing cost across `handlers ∈ {1, 10, 100}`
+  (router map size, one terminal handler per event) and `middleware ∈ {0, 3}`
+  (global middleware depth prepended to every chain).
+
+<!-- benchsync:core:start -->
+Measured on `darwin/arm64` (`Apple M1 Max`).
+
+| Operation | ns/op | B/op | allocs/op |
+|---|---:|---:|---:|
+| `JSONCodec Encode (64 B)` | 390.3 | 144 | 2 |
+| `JSONCodec Encode (1 KiB)` | 3,833 | 1,200 | 2 |
+| `JSONCodec Encode (16 KiB)` | 58,294 | 18,496 | 2 |
+| `JSONCodec Decode (64 B)` | 633 | 336 | 7 |
+| `JSONCodec Decode (1 KiB)` | 3,477 | 1,296 | 7 |
+| `JSONCodec Decode (16 KiB)` | 48,459 | 16,656 | 7 |
+| `Message struct alloc` | 0.3164 | 0 | 0 |
+| `Router Dispatch (1 handlers, 0 mw)` | 18.88 | 0 | 0 |
+| `Router Dispatch (1 handlers, 3 mw)` | 23.27 | 0 | 0 |
+| `Router Dispatch (10 handlers, 0 mw)` | 28.86 | 0 | 0 |
+| `Router Dispatch (10 handlers, 3 mw)` | 32.39 | 0 | 0 |
+| `Router Dispatch (100 handlers, 0 mw)` | 33.05 | 0 | 0 |
+| `Router Dispatch (100 handlers, 3 mw)` | 33.73 | 0 | 0 |
+<!-- benchsync:core:end -->

--- a/message_bench_test.go
+++ b/message_bench_test.go
@@ -1,0 +1,26 @@
+package wspulse_test
+
+import (
+	"testing"
+
+	wspulse "github.com/wspulse/core"
+)
+
+// BenchmarkMessageAlloc measures the cost of constructing a Message struct
+// with a payload reference. The bench is allocation-watchdog: a regression
+// adding even one allocation is amplified across millions of operations
+// downstream (every Send and every Dispatch in the workspace constructs or
+// passes a Message).
+//
+// `sink` defeats Go's dead-store elimination so the construction is not
+// optimised away.
+func BenchmarkMessageAlloc(b *testing.B) {
+	payload := jsonPayload(64)
+	var sink wspulse.Message
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sink = wspulse.Message{Event: "bench", Payload: payload}
+	}
+	_ = sink
+}

--- a/message_bench_test.go
+++ b/message_bench_test.go
@@ -6,21 +6,24 @@ import (
 	wspulse "github.com/wspulse/core"
 )
 
+// messageAllocSink is package-level on purpose: writes to it are observable
+// across the program, which prevents the compiler from eliminating the
+// loop body in BenchmarkMessageAlloc as dead code. A function-local var
+// (with `_ = sink` at the end) is not enough — the previous baseline of
+// 0.3164 ns/op (sub-cycle on Apple M1 Max) confirmed the assignments were
+// being optimised away.
+var messageAllocSink wspulse.Message
+
 // BenchmarkMessageAlloc measures the cost of constructing a Message struct
 // with a payload reference. The bench is allocation-watchdog: a regression
 // adding even one allocation is amplified across millions of operations
 // downstream (every Send and every Dispatch in the workspace constructs or
 // passes a Message).
-//
-// `sink` defeats Go's dead-store elimination so the construction is not
-// optimised away.
 func BenchmarkMessageAlloc(b *testing.B) {
 	payload := jsonPayload(64)
-	var sink wspulse.Message
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		sink = wspulse.Message{Event: "bench", Payload: payload}
+		messageAllocSink = wspulse.Message{Event: "bench", Payload: payload}
 	}
-	_ = sink
 }

--- a/message_bench_test.go
+++ b/message_bench_test.go
@@ -22,8 +22,7 @@ var messageAllocSink wspulse.Message
 func BenchmarkMessageAlloc(b *testing.B) {
 	payload := jsonPayload(64)
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		messageAllocSink = wspulse.Message{Event: "bench", Payload: payload}
 	}
 }

--- a/router/router_bench_test.go
+++ b/router/router_bench_test.go
@@ -9,17 +9,6 @@ import (
 	"github.com/wspulse/core/router"
 )
 
-// benchConn is a noop Connection implementation used by the dispatch bench.
-// The router does not call any of these methods during a normal Dispatch
-// (handlers may, but the bench handlers do not).
-type benchConn struct{}
-
-func (benchConn) ID() string                   { return "bench-conn" }
-func (benchConn) RoomID() string               { return "bench-room" }
-func (benchConn) Send(_ wspulse.Message) error { return nil }
-func (benchConn) Close() error                 { return nil }
-func (benchConn) Done() <-chan struct{}        { return nil }
-
 // jsonPayload returns a valid JSON string payload of total byte length size.
 func jsonPayload(size int) []byte {
 	if size < 2 {
@@ -68,7 +57,7 @@ func BenchmarkRouterDispatch(b *testing.B) {
 					r.On(ev, terminal)
 				}
 
-				conn := benchConn{}
+				conn := newMockConnection("bench-conn", "bench-room")
 				msg := wspulse.Message{
 					Event:   events[routeCount/2],
 					Payload: jsonPayload(64),

--- a/router/router_bench_test.go
+++ b/router/router_bench_test.go
@@ -44,8 +44,10 @@ func jsonPayload(size int) []byte {
 //
 // The bench dispatches the middle-indexed event each iteration to keep
 // map-bucket access pattern stable across runs. A warmup Dispatch is
-// issued before ResetTimer so the one-time lazy chain build and first
-// sync.Pool allocation are not charged to the first iteration.
+// issued before the b.Loop loop so the one-time lazy chain build and
+// first sync.Pool allocation are not charged to the first timed
+// iteration (b.Loop's implicit timer reset happens on its first call,
+// after the warmup has already run).
 func BenchmarkRouterDispatch(b *testing.B) {
 	middleware := func(c *router.Context) { c.Next() }
 	terminal := func(*router.Context) {}

--- a/router/router_bench_test.go
+++ b/router/router_bench_test.go
@@ -31,29 +31,31 @@ func jsonPayload(size int) []byte {
 // BenchmarkRouterDispatch measures the cost of one Dispatch call.
 //
 // The two axes:
-//   - `handlers`: number of distinct events registered (router map size).
-//     Tests lookup cost as the registry grows.
+//   - `routes`: number of distinct events registered (router map size).
+//     Tests lookup cost as the registry grows. Each registered event has
+//     one terminal handler.
 //   - `middleware`: number of global middleware funcs in the chain.
-//     Tests per-handler chain execution cost. Each registered event has
-//     one terminal handler, so total chain length per Dispatch is
-//     middleware + 1.
+//     Tests per-handler chain execution cost. Total chain length per
+//     Dispatch is middleware + 1.
 //
 // The bench dispatches the middle-indexed event each iteration to keep
-// map-bucket access pattern stable across runs.
+// map-bucket access pattern stable across runs. A warmup Dispatch is
+// issued before ResetTimer so the one-time lazy chain build and first
+// sync.Pool allocation are not charged to the first iteration.
 func BenchmarkRouterDispatch(b *testing.B) {
 	noop := func(*router.Context) {}
 
-	for _, handlerCount := range []int{1, 10, 100} {
+	for _, routeCount := range []int{1, 10, 100} {
 		for _, mwDepth := range []int{0, 3} {
-			name := fmt.Sprintf("handlers=%d/middleware=%d", handlerCount, mwDepth)
+			name := fmt.Sprintf("routes=%d/middleware=%d", routeCount, mwDepth)
 			b.Run(name, func(b *testing.B) {
 				r := router.New()
 				for i := 0; i < mwDepth; i++ {
 					r.Use(noop)
 				}
 
-				events := make([]string, handlerCount)
-				for i := 0; i < handlerCount; i++ {
+				events := make([]string, routeCount)
+				for i := 0; i < routeCount; i++ {
 					ev := fmt.Sprintf("event%d", i)
 					events[i] = ev
 					r.On(ev, noop)
@@ -61,9 +63,13 @@ func BenchmarkRouterDispatch(b *testing.B) {
 
 				conn := benchConn{}
 				msg := wspulse.Message{
-					Event:   events[handlerCount/2],
+					Event:   events[routeCount/2],
 					Payload: jsonPayload(64),
 				}
+
+				// Warmup: triggers lazy chain build and primes sync.Pool so
+				// neither cost is charged to the first timed iteration.
+				r.Dispatch(conn, msg)
 
 				b.ReportAllocs()
 				b.ResetTimer()

--- a/router/router_bench_test.go
+++ b/router/router_bench_test.go
@@ -38,12 +38,17 @@ func jsonPayload(size int) []byte {
 //     Tests per-handler chain execution cost. Total chain length per
 //     Dispatch is middleware + 1.
 //
+// Middleware handlers call `c.Next()` (matching the existing
+// `BenchmarkDispatch` in router_test.go) so the bench measures the real
+// recursive chain-traversal cost; the terminal handler is a no-op.
+//
 // The bench dispatches the middle-indexed event each iteration to keep
 // map-bucket access pattern stable across runs. A warmup Dispatch is
 // issued before ResetTimer so the one-time lazy chain build and first
 // sync.Pool allocation are not charged to the first iteration.
 func BenchmarkRouterDispatch(b *testing.B) {
-	noop := func(*router.Context) {}
+	middleware := func(c *router.Context) { c.Next() }
+	terminal := func(*router.Context) {}
 
 	for _, routeCount := range []int{1, 10, 100} {
 		for _, mwDepth := range []int{0, 3} {
@@ -51,14 +56,14 @@ func BenchmarkRouterDispatch(b *testing.B) {
 			b.Run(name, func(b *testing.B) {
 				r := router.New()
 				for i := 0; i < mwDepth; i++ {
-					r.Use(noop)
+					r.Use(middleware)
 				}
 
 				events := make([]string, routeCount)
 				for i := 0; i < routeCount; i++ {
 					ev := fmt.Sprintf("event%d", i)
 					events[i] = ev
-					r.On(ev, noop)
+					r.On(ev, terminal)
 				}
 
 				conn := benchConn{}

--- a/router/router_bench_test.go
+++ b/router/router_bench_test.go
@@ -1,0 +1,76 @@
+package router_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	wspulse "github.com/wspulse/core"
+	"github.com/wspulse/core/router"
+)
+
+// benchConn is a noop Connection implementation used by the dispatch bench.
+// The router does not call any of these methods during a normal Dispatch
+// (handlers may, but the bench handlers do not).
+type benchConn struct{}
+
+func (benchConn) ID() string                   { return "bench-conn" }
+func (benchConn) RoomID() string               { return "bench-room" }
+func (benchConn) Send(_ wspulse.Message) error { return nil }
+func (benchConn) Close() error                 { return nil }
+func (benchConn) Done() <-chan struct{}        { return nil }
+
+// jsonPayload returns a valid JSON string payload of total byte length size.
+func jsonPayload(size int) []byte {
+	if size < 2 {
+		size = 2
+	}
+	return []byte(`"` + strings.Repeat("x", size-2) + `"`)
+}
+
+// BenchmarkRouterDispatch measures the cost of one Dispatch call.
+//
+// The two axes:
+//   - `handlers`: number of distinct events registered (router map size).
+//     Tests lookup cost as the registry grows.
+//   - `middleware`: number of global middleware funcs in the chain.
+//     Tests per-handler chain execution cost. Each registered event has
+//     one terminal handler, so total chain length per Dispatch is
+//     middleware + 1.
+//
+// The bench dispatches the middle-indexed event each iteration to keep
+// map-bucket access pattern stable across runs.
+func BenchmarkRouterDispatch(b *testing.B) {
+	noop := func(*router.Context) {}
+
+	for _, handlerCount := range []int{1, 10, 100} {
+		for _, mwDepth := range []int{0, 3} {
+			name := fmt.Sprintf("handlers=%d/middleware=%d", handlerCount, mwDepth)
+			b.Run(name, func(b *testing.B) {
+				r := router.New()
+				for i := 0; i < mwDepth; i++ {
+					r.Use(noop)
+				}
+
+				events := make([]string, handlerCount)
+				for i := 0; i < handlerCount; i++ {
+					ev := fmt.Sprintf("event%d", i)
+					events[i] = ev
+					r.On(ev, noop)
+				}
+
+				conn := benchConn{}
+				msg := wspulse.Message{
+					Event:   events[handlerCount/2],
+					Payload: jsonPayload(64),
+				}
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					r.Dispatch(conn, msg)
+				}
+			})
+		}
+	}
+}

--- a/router/router_bench_test.go
+++ b/router/router_bench_test.go
@@ -77,8 +77,7 @@ func BenchmarkRouterDispatch(b *testing.B) {
 				r.Dispatch(conn, msg)
 
 				b.ReportAllocs()
-				b.ResetTimer()
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					r.Dispatch(conn, msg)
 				}
 			})


### PR DESCRIPTION
## Summary

Release v0.6.1 — adds a checked-in benchmark harness for `core`. Pure dev tooling: no public API or runtime behaviour changes.

## Related issues

Closes #40

## Changes

- Add `message_bench_test.go` (Message alloc watchdog) and `router/router_bench_test.go` (dispatch matrix: middleware count × handler count, with a middleware bench that calls `c.Next` to avoid the no-op shortcut)
- Add `make bench-ci` and `make bench-sync` targets (portable `mktemp` template, bash scoped per-target, streamed output, failure propagation, `set -o pipefail`)
- Add `cmd/benchsync/` table generator that regenerates `doc/bench.md` from a fresh bench run; singular `handler` label when `hc=1`; `-benchmem` requirement documented; failure on missing rows
- Add `.github/workflows/benchmark.yml` uploading `bench.txt` as an artefact on every code PR (ignores Markdown / LICENSE / `.github/instructions/**` changes)
- Check in first-iteration baseline at `doc/bench.md` (post-`b.Loop` migration)
- Promote `[Unreleased]` to `[0.6.1] - 2026-05-18` in CHANGELOG; add v0.6.0...v0.6.1 compare link

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] Performance-sensitive change: benchmark included (this PR _is_ the benchmark harness; baseline at `doc/bench.md`)